### PR TITLE
Update the default font awesome selector so it doesn't break older/ex…

### DIFF
--- a/assets/sass/foundations/icons.scss
+++ b/assets/sass/foundations/icons.scss
@@ -36,7 +36,7 @@
 }
 
 // Font awesome support
-[class*="fa-"]:not(.far) {
+.icon[class*="fa-"]:not(.far) {
   font-size: rem(64 - 16);
   height: rem(64);
   padding: 0.5rem;

--- a/docs/views/Changelog.vue
+++ b/docs/views/Changelog.vue
@@ -3,6 +3,10 @@
     <div class="container">
       <h1>Changelog</h1>
       
+      <h2>V2.6.2</h2>
+      <ul>
+        <li>Update the default font awesome selector so it doesn't break older/existing font awesome usage.</li>
+      </ul>
       <h2>V2.6.1</h2>
       <ul>
         <li>Update stepper hover states</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iamproperty/components",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "private": false,
   "description": "Component library for iamproperty",
   "author": {


### PR DESCRIPTION
Update the default font awesome selector so it doesn't break older/existing font awesome usage.

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /foundations/icons

## Ticket(s)
DS-157
