### PR TITLE
Market place nav dark mode

### DIFF
--- a/assets/sass/components/nav.scss
+++ b/assets/sass/components/nav.scss
@@ -746,7 +746,7 @@ nav + main > *:first-child {
       height: calc(100vh - var(--nav-height));
       width: rem(400);
       position: absolute;
-      top: calc(var(--nav-height));
+      top: var(--nav-height);
       z-index: 60;
       background: var(--bs-body-bg);
       overflow-y: auto;

--- a/docs/views/Changelog.vue
+++ b/docs/views/Changelog.vue
@@ -3,12 +3,17 @@
     <div class="container">
       <h1>Changelog</h1>
       
-      <h2>V2.7.5 (Future version)</h2>
+      <h2>V2.7.6</h2>
+      <ul>
+        <li>Minor fixes for the marketplace nav so it works better in dark mode.</li>
+      </ul>
+
+      <h2>V2.7.5</h2>
       <ul>
         <li>Add extra tick list classes</li>
       </ul>
       
-      <h2>V2.7.4 (current version)</h2>
+      <h2>V2.7.4</h2>
       <ul>
         <li>Fix marketplace nav</li>
       </ul>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iamproperty/components",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "private": false,
   "description": "Component library for iamproperty",
   "author": {
@@ -11,7 +11,7 @@
     "build": "vue-cli-service build --target lib src/index.js",
     "lint": "vue-cli-service lint",
     "audit": "node local_modules/audit.js",
-    "build:docs": "vue-cli-service build docs/main.js",
+    "build:docs": "npm run copy:svg && vue-cli-service build docs/main.js",
     "compile:js": "rollup --environment BUNDLE:true --config rollup.config.js --sourcemap && terser --compress passes=2 --mangle --comments \"/^!/\" --source-map \"content=assets/js/scripts.bundle.js.map,includeSources,url=scripts.bundle.min.js.map\" --output assets/js/scripts.bundle.min.js assets/js/scripts.bundle.js",
     "compile:sass": "sass assets/sass/main.scss assets/css/style.min.css --style=compressed && sass assets/sass/core.scss assets/css/core.min.css --style=compressed",
     "compile:email": "sass assets/sass/email.scss assets/css/email.min.css --style=compressed && node local_modules/email-css.js",


### PR DESCRIPTION
## Summary of Changes
1. Minor fix for marketplace nav in dark mode 

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /standalone/marketplace (while in dark mode)

