### PR TITLE
FEG-53/feature/update modal page

### DIFF
--- a/assets/sass/components/card.scss
+++ b/assets/sass/components/card.scss
@@ -129,6 +129,12 @@
   vertical-align: middle;
 }
 
+.card--filter ::slotted(i) {
+  display: block !important;
+  height: rem(18)!important;
+  margin: 0 0 0.5rem 0!important;
+}
+
 ::slotted(span){
   display: block;
   font-weight: normal;

--- a/assets/sass/components/card.scss
+++ b/assets/sass/components/card.scss
@@ -30,7 +30,6 @@
   }
 
   &__body {
-    
     position: relative;
     padding: var(--top-padding) var(--right-padding) var(--bottom-padding) var(--left-padding);
     z-index: -1;
@@ -124,16 +123,13 @@
 
 
 ::slotted(i){
-  
-  font-size: rem(18)!important;
-  height: rem(18)!important;
-  margin: 0 0 0.5rem 0!important;
-  font-weight: 400!important;
-  display: block!important;
+  font-size: rem(24);
+  margin: -3px var(--icon-right) 0 0;
+  font-weight: 400;
+  vertical-align: middle;
 }
 
 ::slotted(span){
-  
   display: block;
   font-weight: normal;
   padding-top: rem(24);

--- a/assets/sass/components/dialog.scss
+++ b/assets/sass/components/dialog.scss
@@ -61,7 +61,8 @@ dialog[open] {
     }
 
     & + * {
-      padding-right: rem(36);
+      padding-right: var(--dialog-padding);
+      margin-right: rem(20);
     }
   }
 
@@ -76,27 +77,21 @@ dialog[open] {
 
 // #region modal styling
 *:not(.dialog__wrapper) > dialog[open] {
-  
-  min-width: 100%;
-  max-width: 80vw;
-  max-height: 85vh;
-  margin-top: 12vh;
+  overflow-y: hidden;
+  width: 90vw;
+  max-width: rem(376); // col-width*4 // 96px*4 = 376px
+  height: fit-content;
 
   @include media-breakpoint-up(sm) {
     
-    --dialog-padding: #{rem(56)};
+    --dialog-padding: #{rem(32)};
 
-    min-width: 80vw;
-    max-height: 80vh;
-    margin-top: auto;
+    max-width: rem(564); // col-width*6 // 96px*6 = 564px
     border-radius: rem(34);
   }
   
   @include media-breakpoint-up(md) {
     
-    min-width: rem(1112);
-    width: rem(1112);
-    max-width: rem(1112);
   }
 
   &:has(.youtube-embed){
@@ -104,10 +99,22 @@ dialog[open] {
   }
 }
 
+.mh-lg {
+  padding-right: rem(20);
+
+  @include media-breakpoint-up(md) {
+    margin-right: var(--dialog-padding);
+  }
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+}
 
 
 dialog::backdrop {
   background: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(4px);
 }
 // #endregion
 

--- a/assets/ts/components/card/card.component.ts
+++ b/assets/ts/components/card/card.component.ts
@@ -8,7 +8,7 @@ class iamCard extends HTMLElement {
     const assetLocation = document.body.hasAttribute('data-assets-location') ? document.body.getAttribute('data-assets-location') : '/assets';
     const loadCSS = `@import "${assetLocation}/css/components/card.css";`;
 
-    if(this.querySelector('.icon'))
+    if(this.querySelector('.fa'))
       this.classList.add('card--has-icon');
 
     let classList = this.classList.toString();

--- a/assets/ts/modules/helpers.ts
+++ b/assets/ts/modules/helpers.ts
@@ -75,6 +75,12 @@ export const addGlobalEvents = (body) => {
       // Create close button is needed
       dialog.innerHTML = `<button class="dialog__close">Close</button>${dialog.innerHTML}`;
       
+      // remove close button when dialog is closed
+      dialog.addEventListener("close", () => {
+        const closeButton = dialog.querySelector('.dialog__close');
+        dialog.removeChild(closeButton);
+      }, { once: true }); // only adds this once
+      
       let videoButton = dialog.querySelector('.youtube-embed a');
 
       if (videoButton){
@@ -89,8 +95,8 @@ export const addGlobalEvents = (body) => {
         "id": modalID
       });
     };
-    // Close modal
 
+    // Close modal
     if (event && event.target instanceof HTMLElement && event.target.closest('button.dialog__close')){
       const dialog = event.target.closest('dialog[open]');
 
@@ -107,7 +113,9 @@ export const addGlobalEvents = (body) => {
     if (event && event.target instanceof HTMLElement && event.target.closest('dialog[open]')){
       const dialog = event.target.closest('dialog[open]');
       const dialogDimensions = dialog.getBoundingClientRect()
+
       if (event.clientX < dialogDimensions.left || event.clientX > dialogDimensions.right || event.clientY < dialogDimensions.top || event.clientY > dialogDimensions.bottom) {
+
         dialog.close()
         
         window.dataLayer = window.dataLayer || [];

--- a/docs/views/Changelog.vue
+++ b/docs/views/Changelog.vue
@@ -7,6 +7,9 @@
       <ul>
         <li>Update to Admin panels documentation</li>
         <li>Minor button amends</li>
+        <li>Update to dialog (modal / popover) documentation</li>
+        <li>Update to dialog style, max height and width</li>
+        <li>Update to Cards component when icon is included</li>
       </ul>
 
       <h2>V3.5</h2>

--- a/docs/views/components/CardDoc.vue
+++ b/docs/views/components/CardDoc.vue
@@ -34,6 +34,17 @@
           </a>          
         </div>
       </div>
+      <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 mb-4 pe-none">
+        <div class="col">
+          <span class="pb-3 d-block text-uppercase">With Icon</span>
+          <a href="/client-onbaording">
+            <Card>
+              <i class="fa fa-home"></i>
+              Lorem Ipsum
+            </Card>
+          </a>          
+        </div>
+      </div>
     </div>
     <div class="container">
 

--- a/docs/views/components/DialogDoc.vue
+++ b/docs/views/components/DialogDoc.vue
@@ -1,80 +1,105 @@
 <template>
   <main>
+    
+    <DSHeader :image="headerImg" section="components">
+      <h1>Dialog (popover / modal)</h1>
+    </DSHeader>
+
     <div class="container">
-      <ul class="breadcrumb mb-0 d-sm-none">
-        <li><a href="/components">Components</a></li>
-      </ul>
+      <p class="lead">The dialog component can be used as an inline popover to reveal content on a button click, or as a traditional modal taking up the whole screen. Use this to hide away secondary information so that it can be viewed when the user requires it.</p>
       <h2>Modal</h2>
-      <p>Hide away secondary information so that it can be viewed upon request.</p>
-      <button data-modal="modal" class="btn btn-secondary">Open modal</button>
+      <p>The traditional modal use the bootstrap approach of <kbd>data-modal="[modal_id]"</kbd> on a button to show the targeted dialog with matching id. Supports backdrop click or escape key to hide. Add a div with class <kbd>mh-lg</kbd> to allow scrollable content.</p>
+      <button data-modal="modal" class="btn btn-secondary">Open Modal</button>
     </div>
     
-    <dialog id="modal">
-      <h2>Modal content</h2>
-      <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,</p>
-      <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+    <dialog id="modal" class="mh">
+      <h3>Dialog Content (Modal)</h3>
+      <div class="mh-lg">
+        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,</p>
+        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,</p>
+        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,</p>
+        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+      </div>
     </dialog>
-    
-    <div class="container">
-      <ul class="breadcrumb mb-0 d-sm-none">
-        <li><a href="/components">Components</a></li>
-      </ul>
-      <h2>Popover</h2>
-      <p>Hide away secondary information so that it can be viewed upon request.</p>
-      <div class="dialog__wrapper">
 
-        <button class="btn btn-secondary">Open modal</button>
+    
+
+    <div class="container">
+      <h2>Popover</h2>
+      <p>For inline wrap the button and dialog in a div with class: <kbd>dialog__wrapper</kbd>.</p>
+      <div class="dialog__wrapper">
+        <button class="btn btn-secondary">Open Popover</button>
         <dialog>
-          <h2>Modal content</h2>
+          <h3>Dialog Content (Popover)</h3>
           <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,</p>
         </dialog>
       </div>
     </div>
     
-    
-    
 
-    <div class="container">
-      <ul class="breadcrumb mb-0 d-sm-none">
-        <li><a href="/components">Components</a></li>
-      </ul>
-      <h2>YouTube video Modal</h2>
-      <p>We can add a YouTube video to a modal which would play/load once the modal is opened.</p>
-      <button data-modal="youtubewrapper" class="btn btn-secondary">Open YouTube video modal</button>
-    </div>
     
+    <div class="container">
+      <h2>Dialog Content (Modal) - YouTube Video</h2>
+      <p>We can add a YouTube video to a modal which would play/load once the modal is opened. Same implementation as the modal above, passing through the YoutubeVideo component as the content of the dialog.</p>
+      <button data-modal="youtubewrapper" class="btn btn-secondary">Open YouTube Video Modal</button>
+    </div>
 
     <dialog id="youtubewrapper">
       <YoutubeVideo video="fXyAMkQzDls"></YoutubeVideo>
     </dialog>
-    
 
-    <div class="container" id="return">
-      <h2>HTML code examples</h2>
-      <pre><code class="javascript">{{htmlUsage}}</code></pre>
+
+
+    <div class="container">
+      <Tabs>
+        <details>
+          <summary><h2>HTML</h2></summary>
+          <pre><code class="javascript">{{htmlUsage}}</code></pre>
+        </details>
+      </Tabs>
     </div>
 
   </main>
 </template>
 
 <script>
+import Tabs from '@/components/Tabs/Tabs.vue'
 import YoutubeVideo from '@/foundations/YoutubeVideo/YoutubeVideo.vue'
+import DSHeader from '../DSHeader.vue'
+import headerImg from '../../img/type-header.png'
 
 export default {
   components: {
-    YoutubeVideo
+    YoutubeVideo,
+    DSHeader,
+    Tabs,
   },
   data () {
     return {
-      htmlUsage: `<div class="modal" :d="id">
-  <a :href="#close"><span class="visually-hidden">Close</span></a>
-  <div class="modal__outer">
-    <a :href="#close" class="btn btn-tertiary py-1 px-2"><span class="visually-hidden">Close</span>✕</a>
-    <div class="modal__inner">
-      <!-- content -->
-    </div>
-  </div>
-</div>`
+      headerImg: headerImg,
+      htmlUsage: `
+      <!-- Modal Version -->
+      <button data-modal="modal" class="btn btn-secondary">Open Modal</button>
+      
+      <dialog id="modal">
+        <h3>Dialog Content (Modal)</h3>
+        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,</p>
+        <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</p>
+      </dialog>
+
+
+      <!-- Popover Version -->
+      <div class="dialog__wrapper">
+        <button class="btn btn-secondary">Open Popover</button>
+        <dialog>
+          <h3>Dialog Content (Popover)</h3>
+          <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,</p>
+        </dialog>
+      </div>
+
+      `
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iamproperty/components",
-  "version": "3.5.0",
+  "version": "3.5.1.--alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iamproperty/components",
-      "version": "3.5.0",
+      "version": "3.5.1.--alpha",
       "license": "UNLICENSED",
       "dependencies": {
         "bootstrap": "^5.2.0"


### PR DESCRIPTION
## Summary of Changes
1. Dialog component
- Improved style of Dialog component (max width, height and responsive)
- Updated dialog documentation page with above changes
- Fixed close icon repeatedly adding to dialog
2. Card component 
- Improved styling when FA icon is used
- Updated card documentation page with above changes
- Changed query selector to `.fa` instead of unnecessary `.icon`


## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /components/dialog
- /components/card

## Ticket(s)
FEG-53

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request` **_Fails on unchanged files and timeout errors_**
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
