### PR TITLE
Feg 103/bug/out of viewport popover

### DIFF
--- a/assets/ts/modules/dialogs.ts
+++ b/assets/ts/modules/dialogs.ts
@@ -135,7 +135,18 @@ const extendDialogs = (body) => {
           popover.setAttribute('style',`position:fixed;top: ${topOffset}px; left: ${leftOffset}px; margin: 3rem 0 0 0;`)
         }
       }
-        
+      
+      // When the dialog is fixed it could dip under the viewport
+      // Lets check the dimensions and transform it to appear above
+      let boundingRec = popover.getBoundingClientRect();
+      let popoverBottom = boundingRec.bottom - window.scrollY;
+      let windowPos = window.innerHeight - window.scrollY;
+      if(popoverBottom > windowPos){
+
+        let currentStyle = popover.getAttribute('style');
+
+        popover.setAttribute('style',currentStyle+`transform: translate(0, calc(-100% - 4rem))`);
+      }
 
       window.dataLayer = window.dataLayer || [];
       

--- a/audit.json
+++ b/audit.json
@@ -1,7 +1,7 @@
 {
   "css_size": "204kb",
   "css_core_size": "141kb",
-  "js_size": "46kb",
+  "js_size": "47kb",
   "logo_size": "24kb",
   "img_size": "9kb",
   "img_count": 1,


### PR DESCRIPTION
## Summary of Changes
1. When the dialog is fixed it could dip under the viewport so this JS adds a CSS transform when needed

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /standalone/openview

## Ticket(s)
FEG-103

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
