### PR TITLE
Feg 102/bug/sticky active state buttons

### DIFF
--- a/assets/ts/components/table/table.component.ts
+++ b/assets/ts/components/table/table.component.ts
@@ -97,8 +97,12 @@ class iamTable extends HTMLElement {
 
     this.shadowRoot.querySelector('.table__wrapper').addEventListener("scroll", (event) => {
 
-      if(this.table.querySelector('dialog[open]'))
+      if(this.table.querySelector('dialog[open]')){
+        
         this.table.querySelector('dialog[open]').close();
+        this.table.querySelector('.dialog__wrapper > button.active').classList.remove('active');
+      }
+
     });
   }
 

--- a/assets/ts/modules/dialogs.ts
+++ b/assets/ts/modules/dialogs.ts
@@ -31,10 +31,7 @@ const extendDialogs = (body) => {
 
       // Open the modal!
       dialog.showModal();
-
       dialog.focus();
-
-      console.log(dialog.querySelector('button'));
 
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
@@ -49,7 +46,12 @@ const extendDialogs = (body) => {
 
       event.preventDefault();
       dialog.close()
-        
+      
+      // Remove active class from exiting active buttons
+      Array.from(document.querySelectorAll('.dialog__wrapper > button')).forEach((btnElement,index) => {
+        btnElement.classList.remove('active');
+      });
+
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         "event": "closeModal",
@@ -61,6 +63,11 @@ const extendDialogs = (body) => {
     if (event && event.target instanceof HTMLElement && event.target.closest('button[formmethod="dialog"]')){
       const dialog = event.target.closest('dialog[open]');
 
+      // Remove active class from exiting active buttons
+      Array.from(document.querySelectorAll('.dialog__wrapper > button')).forEach((btnElement,index) => {
+        btnElement.classList.remove('active');
+      });
+      
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         "event": "closeModal",
@@ -105,6 +112,11 @@ const extendDialogs = (body) => {
         document.querySelector('dialog[open]').close();
 
 
+      // Remove active class from exiting active buttons
+      Array.from(document.querySelectorAll('.dialog__wrapper > button')).forEach((btnElement,index) => {
+        btnElement.classList.remove('active');
+      });
+
       if(popover.hasAttribute('open')){
         
         popover.close();
@@ -128,7 +140,6 @@ const extendDialogs = (body) => {
 
           topOffset -= container.top;
           leftOffset -= container.left;
-
         }
 
         if(popover.classList.contains('dialog--fix')){

--- a/audit.json
+++ b/audit.json
@@ -1,6 +1,6 @@
 {
-  "css_size": "205kb",
-  "css_core_size": "141kb",
+  "css_size": "203kb",
+  "css_core_size": "139kb",
   "js_size": "47kb",
   "logo_size": "24kb",
   "img_size": "9kb",


### PR DESCRIPTION
## Summary of Changes
1. Remove active states on buttons for the popovers

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /standalone/openview

## Ticket(s)
FEG-102

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
