### PR TITLE
FEG-138/bug/flexible-widths-dialogs

### DIFF
--- a/assets/sass/components/dialog.scss
+++ b/assets/sass/components/dialog.scss
@@ -37,6 +37,11 @@ dialog[open] {
 // #endregion
 
 // #region modal styling
+
+*:not(.dialog__wrapper) > dialog[open] {
+
+}
+
 *:not(.dialog__wrapper) > dialog[open] {
   overflow-y: hidden;
   width: 90vw;
@@ -135,16 +140,9 @@ dialog[open] {
     max-width: rem(1112);
   }
 
-  container-type: inline-size;
-    
-  @container (width < 23.4375em) {
+  @media screen and (max-width: 36em) {
 
-    > .btn:not(.dialog__close),
-    > form > .btn:not(.dialog__close),
-    > .mh-lg > :is(form,div) > .btn:not(.dialog__close),
-    > .mh-lg > .btn:not(.dialog__close),
-    > form > fieldset > .btn:not(.dialog__close),
-    .btn--wrapper > .btn:not(.dialog__close) {
+    :is(form, fieldset, .btn--wrapper):has(> .btn:first-child, > .btn:last-child) .btn:not(.dialog__close) {
       width: 100%;
       max-width: 100%;
       margin: 0;
@@ -242,6 +240,7 @@ dialog::backdrop {
 
   &:not(:has(fieldset.active)) fieldset:first-of-type{
     display: flex;
+    flex-direction: column;
   }
 
   form > *:not(fieldset) {
@@ -319,6 +318,11 @@ dialog::backdrop {
     }
   }
 
+  @include media-breakpoint-up(sm) {
+    min-width: rem(452);
+    width: rem(452);
+    max-width: rem(452);
+  }
   @include media-breakpoint-up(md) {
     min-width: rem(924);
     width: rem(924);


### PR DESCRIPTION
## Summary of Changes
1. Updated dialog CSS to use media query instead of container query which was causing issues

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /components/modal

## Ticket(s)
FEG-138

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
