### PR TITLE
FEG-151 Update table.ts

### DIFF
--- a/assets/ts/modules/table.ts
+++ b/assets/ts/modules/table.ts
@@ -781,12 +781,8 @@ export const makeTableFunctional = function(table, form, pagination, wrapper){
   // Work out the largest width of the CTA's in the last column
   if(wrapper && wrapper.classList.contains('table--cta')){
 
-    if(!wrapper.hasAttribute('data-cta-width')){
-        
-      const largestWidth = getLargestLastColWidth(table);
-      wrapper.style.setProperty("--cta-width", `${largestWidth}rem`);
-      wrapper.setAttribute("data-cta-width", `${largestWidth}rem`);
-    }
+    const largestWidth = getLargestLastColWidth(table);
+    wrapper.style.setProperty("--cta-width", `${largestWidth}rem`);
 
     function outputsize() {
 


### PR DESCRIPTION
Aways update the cta width even if already set

## Summary of Changes
1. Aways update the cta width even if already set

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
N/A
## Ticket(s)
FEG-151

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
