### PR TITLE
Add own icon

### DIFF
--- a/assets/sass/components/dialog.scss
+++ b/assets/sass/components/dialog.scss
@@ -183,6 +183,7 @@ dialog::backdrop {
 
   text-align: center;
 
+
   &:before {
     content: "\f05a";
     font-weight: 300;
@@ -203,6 +204,38 @@ dialog::backdrop {
     line-height: 1;
     color: var(--colour-heading);
     clear: both;
+  }
+
+  &:has(> i):before{
+
+    display: none;
+  }
+
+  &:has(> i) > i{
+
+    display: var(--fa-display,inline-block);
+    line-height: 1;
+    font-size: 3rem;
+    @include media-breakpoint-up(md) {
+      font-size: 4rem;
+    }
+    margin-top: 0;
+    margin-bottom: rem(24);
+    line-height: 1;
+    color: var(--colour-heading);
+    clear: both;
+
+    &:has(> i){
+      position: relative;
+    }
+
+    > i:before {
+      content: "\f2ed";
+      position: absolute;
+      top: 0;
+      left: 50%;
+      transform: scale(0.5) translate(-100%,0);
+    }
   }
 
   > form:first-child button,

--- a/docs/views/components/ModalDoc.vue
+++ b/docs/views/components/ModalDoc.vue
@@ -115,6 +115,8 @@
       <button data-modal="modal-transactional" class="btn btn-secondary">Open Modal</button>
     </div>
     <dialog id="modal-transactional">
+
+      <i class="fa-light fa-circle"><i class="fa-regular fa-trash-can"></i></i>
       
       <span class="h3">Delete property file</span>
       <p>Continually will permanently delete this property. Are you sure you’d like to continue?</p>


### PR DESCRIPTION
## Summary of Changes
1. Allow for the icon to be updated by adding own i element

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /components/modal (transactional modal)

## Ticket(s)
FEG-212

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
