### PR TITLE
Feg 258/bug/filter cards duplicate in dialog

### DIFF
--- a/assets/sass/components/nav-global.scss
+++ b/assets/sass/components/nav-global.scss
@@ -110,7 +110,7 @@ iam-nav {
     text-decoration: none;
   }
 
-  a:not([slot="logo"]):not(:has(iam-card)) {
+  a:not([slot="logo"]):not(.btn):not(:has(iam-card)) {
     
     text-decoration: none;
 
@@ -489,7 +489,7 @@ iam-nav details {
       }
     }
 
-    a:not([slot="logo"]):not(:has(iam-card)) {
+    a:not([slot="logo"]):not(.btn):not(:has(iam-card)) {
 
       font-size: 1rem;
       line-height: rem(24);

--- a/assets/ts/components/card/card.component.ts
+++ b/assets/ts/components/card/card.component.ts
@@ -44,7 +44,7 @@ class iamCard extends HTMLElement {
   }
 
 	connectedCallback() {
-    
+
     this.classList.add('loaded');
     
     // Mimic clicking the parent node so the focus and target events can be on the card
@@ -67,8 +67,6 @@ class iamCard extends HTMLElement {
     // Click event down
     this.addEventListener('click', (event) => {
 
-      event.stopPropagation();
-      event.preventDefault();
       let clickEvent = new Event('click');
       card.dispatchEvent(clickEvent);
     });

--- a/assets/ts/components/card/card.component.ts
+++ b/assets/ts/components/card/card.component.ts
@@ -64,6 +64,15 @@ class iamCard extends HTMLElement {
         card.classList.remove('checked');
     }
 
+    // Click event down
+    this.addEventListener('click', (event) => {
+
+      event.stopPropagation();
+      event.preventDefault();
+      let clickEvent = new Event('click');
+      card.dispatchEvent(clickEvent);
+    });
+
     card.addEventListener('click', (event) => {
 
       if(parentNode.matches('label[for]')){
@@ -151,7 +160,8 @@ class iamCard extends HTMLElement {
   attributeChangedCallback(attrName, oldVal, newVal) {
     switch (attrName) {
       case "data-total": {
-        this.shadowRoot.querySelector('.card__total').innerHTML = newVal;
+        if(this.shadowRoot.querySelector('.card__total'))
+          this.shadowRoot.querySelector('.card__total').innerHTML = newVal;
         break;
       }
       case "class": {

--- a/assets/ts/modules/applied-filters.ts
+++ b/assets/ts/modules/applied-filters.ts
@@ -96,17 +96,14 @@ function createAppliedFilters(container,filters) {
   Array.from(container.querySelectorAll('input[type="checkbox"]:checked')).forEach((input, index) => {
     addFilterButton(filters, input)
   });
-  
-  container.addEventListener('change', function(event){
 
-    if (event && event.target instanceof HTMLElement && event.target.closest('input[data-filter-text]')){
-
-      let input = event.target.closest('input[data-filter-text]');
+  Array.from(container.querySelectorAll('input[type="checkbox"][data-filter-text]')).forEach((input, index) => {
+    
+    input.addEventListener('change', function(event){
 
       addFilterButton (filters, input);
-    };
-    
-  }, false);
+    }, false);
+  });
 
   filters.addEventListener('click', function(event){
 
@@ -136,7 +133,8 @@ function createAppliedFilters(container,filters) {
             input.checked = false;
 
             var event = new Event('force');
-            input.closest('form').dispatchEvent(event);
+            if(!container.hasAttribute('data-nosubmit'))
+              input.closest('form').dispatchEvent(event);
           }
         }
       }

--- a/assets/ts/modules/dialogs.ts
+++ b/assets/ts/modules/dialogs.ts
@@ -36,6 +36,23 @@ const extendDialogs = (body) => {
       dialog.showModal();
       dialog.focus();
 
+      let firstWidth = dialog.offsetWidth;
+      dialog.setAttribute('style',`max-width: ${firstWidth}px;`);
+
+      // When the modal is opened we want to make sure any duplicate checkboxes are matching the originals
+      Array.from(dialog.querySelectorAll('[data-duplicate]')).forEach((element,index) => {
+        
+        const id = element.getAttribute('data-duplicate');
+        const originalInput = document.getElementById(id);
+
+        if(element.checked != originalInput.checked){
+
+          element.checked = originalInput.checked;
+          let changeEvent = new Event('change');
+          element.dispatchEvent(changeEvent);
+        }
+      });
+
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         "event": "openModal",

--- a/assets/ts/modules/table.ts
+++ b/assets/ts/modules/table.ts
@@ -279,6 +279,17 @@ export const addFilterEventListeners = (table, form, pagination, wrapper, savedT
       
       form.reset();
 
+      // Make sure any applied filters have been removed
+      Array.from(form.querySelectorAll('.applied-filters')).forEach((filters,index) => {
+        filters.innerHTML = "";
+      });
+
+      // Make sure cards are unlicked
+      Array.from(form.querySelectorAll('label iam-card')).forEach((card,index) => {
+        let clickEvent = new Event('click');
+        card.dispatchEvent(clickEvent);
+      });
+
       if(!form.hasAttribute('data-submit'))
         sortTable(table, form, savedTableBody);
 

--- a/assets/ts/modules/table.ts
+++ b/assets/ts/modules/table.ts
@@ -140,7 +140,35 @@ export const addFilterEventListeners = (table, form, pagination, wrapper, savedT
   var timer;
 
   // Check what conditions are set on the table to see what the form actions are
-  let formSubmit = function(paginate = false){
+  let formSubmit = function(event, paginate = false){
+
+    if(form.classList.contains('processing'))
+      return false;
+
+
+    // Before submitting check if any duplicate checkboxes within the filters dialog needs to upset the original input
+    if(event.type == "submit"){
+      form.classList.add('processing');
+      Array.from(form.querySelectorAll('[data-duplicate]')).forEach((element,index) => {
+
+        const id = element.getAttribute('data-duplicate');
+        const input = document.getElementById(id);
+        const card = document.querySelector(`[for="${id}"] iam-card`);
+
+
+        if(input.checked != element.checked){
+            
+          if(card){
+            let clickEvent = new Event('click');
+            card.dispatchEvent(clickEvent);
+          }
+          else {
+            input.checked = element.checked;
+          }
+        }
+      });
+      form.classList.remove('processing');
+    }
 
     if(form.hasAttribute('data-ajax')){
 
@@ -179,7 +207,7 @@ export const addFilterEventListeners = (table, form, pagination, wrapper, savedT
     if (event && event.target instanceof HTMLElement && event.target.closest('[data-search]')){
 
       timer = setTimeout(function(){
-        formSubmit();
+        formSubmit(event);
       }, 500);
     };
   });
@@ -193,12 +221,12 @@ export const addFilterEventListeners = (table, form, pagination, wrapper, savedT
       if(!form.hasAttribute('data-submit'))
         sortTable(table, form, savedTableBody);
 
-      formSubmit();
+      formSubmit(event);
     }
 
     if (event && event.target instanceof HTMLElement && event.target.closest('[data-search]')){
         
-      formSubmit();
+      formSubmit(event);
     }
 
     if (event && event.target instanceof HTMLElement && event.target.closest('[data-filter][data-no-ajax]')){ // Allow for input fields to filter the current results without a new ajax call
@@ -209,21 +237,21 @@ export const addFilterEventListeners = (table, form, pagination, wrapper, savedT
     }
     else if (event && event.target instanceof HTMLElement && event.target.closest('[data-filter]') && event.target.closest('form .dialog__wrapper > dialog')){
       
-      formSubmit();
+      formSubmit(event);
     }
     else if (event && event.target instanceof HTMLElement && event.target.closest('[data-filter]') && !event.target.closest('form dialog')){
       
-      formSubmit();
+      formSubmit(event);
     }
 
     if (event && event.target instanceof HTMLElement && event.target.closest('[data-show]')){
         
-      formSubmit();
+      formSubmit(event);
     }
 
     if (event && event.target instanceof HTMLElement && event.target.closest('[data-mimic]')){
         
-      formSubmit();
+      formSubmit(event);
     }
   });
 
@@ -254,7 +282,7 @@ export const addFilterEventListeners = (table, form, pagination, wrapper, savedT
       if(!form.hasAttribute('data-submit'))
         sortTable(table, form, savedTableBody);
 
-      formSubmit();
+      formSubmit(event);
     }
   });
 
@@ -265,17 +293,17 @@ export const addFilterEventListeners = (table, form, pagination, wrapper, savedT
     if(!form.hasAttribute('data-submit'))
       event.preventDefault();
 
-    formSubmit();
+    formSubmit(event);
   });
 
   form.addEventListener('force', (event) => {
 
-    formSubmit();
+    formSubmit(event);
   });
 
   form.addEventListener('paginate', (event) => {
 
-    formSubmit(true);
+    formSubmit(event,true);
   });
 
 

--- a/docs/views/standalone/ComplianceDashboard.vue
+++ b/docs/views/standalone/ComplianceDashboard.vue
@@ -108,11 +108,11 @@
           <div class="row align-items-end">
 
 
-            <div class="col-12 ms-md-auto mw-fit-content">
+            <div class="col-12 ms-md-auto mw-sm-fit-content">
               <button class="btn btn-secondary me-0 d-block w-100 btn-filter mb-1" type="button" data-modal="filters">Filter by <span data-filter-count=""></span></button>
             </div>
 
-            <div class="col-12 mw-fit-content">
+            <div class="col-12 mw-sm-fit-content">
 
                 <div class="dialog__wrapper dialog__wrapper--md-right">
 
@@ -135,6 +135,9 @@
                     </dialog>
                 </div>
 
+            </div>
+            <div class="col-12 mw-sm-fit-content">
+              <button class="btn btn-tertiary me-0" data-clear>Clear filters</button>
             </div>
           </div>  
         </div>

--- a/docs/views/standalone/ComplianceDashboard.vue
+++ b/docs/views/standalone/ComplianceDashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <nav>
-      <iam-nav id="menu" class="bg-primary" style="--max-width: 100rem;--container-padding: 0 1rem;">
+      <iam-nav id="menu" class="bg-primary" data-search>
         
         <a href="/" class="brand brand--sold" slot="logo">
           <svg>
@@ -9,29 +9,17 @@
             <use xlink:href="/svg/logo.svg#logo-sold"></use>
           </svg>
         </a>
-
-        <a href="#menu" class="btn-menu" slot="btn">Menu</a>
         
-        <ul>
-          <li>Hello <a href="/details">Emma Varah</a> (Level 1)</li>
-          <li><a href="/home">Home</a></li>
-          <li><a href="/home" target="_blank">New support ticket <i class="fa-regular fa-arrow-up-right-from-square"></i></a></li>
-        </ul>
+        
+        <a href="/details" slot="secondary">Hello Emma Varah (Level 1)</a>
+        <a href="/home" target="_blank" slot="secondary">New support ticket <i class="fa-regular fa-arrow-up-right-from-square"></i></a>
+        
 
-        <ul slot="secondary">
-          <li><a href="/admin/properties.html">Properties</a></li>
-          <li><a href="/admin/auth/staff.html">Staff</a></li>
-          <li><a href="/admin/reports.html">Reports</a></li>
-          <li><a href="/admin/awards.html">iamvalued Awards</a></li>
-        </ul>
+        <a href="/admin/properties.html">Properties</a>
+        <a href="/admin/auth/staff.html">Staff</a>
+        <a href="/admin/reports.html">Reports</a>
+        <a href="/admin/awards.html">iamvalued Awards</a>
 
-        <form id="search" slot="actions">
-          <div>
-            <label for="search">Search</label>
-            <!--<button class="suffix"><i class="fa-regular fa-magnifying-glass"></i></button>-->
-            <input id="search" name="search" type="text" placeholder="Search by keyword, property, agent or ap ref" autocomplete="off" class="input--inline" />
-          </div>
-        </form>
         <a href="https://iamsold.test/admin/logout.html" class="btn btn-primary" slot="actions">Logout</a>
       
       </iam-nav>
@@ -96,9 +84,9 @@
           <div class="row tab-focus">
 
 
-          <input type="checkbox" name="sla_progress" data-filter="SLA progress" value="Due" id="due_diligience_incomplete" class="d-none" />
-          <input type="checkbox" name="sla_progress" data-filter="SLA progress" value="Upcoming" id="due_diligience_requires_approval" class="d-none" />
-          <input type="checkbox" name="sla_progress" data-filter="SLA progress" value="On track" id="due_diligience_verified" class="d-none" />
+          <input type="checkbox" name="[sla_progress][]" data-filter="SLA progress" value="Due" id="due_diligience_incomplete" class="d-none" />
+          <input type="checkbox" name="[sla_progress][]" data-filter="SLA progress" value="Upcoming" id="due_diligience_requires_approval" class="d-none" />
+          <input type="checkbox" name="[sla_progress][]" data-filter="SLA progress" value="On track" id="due_diligience_verified" class="d-none" />
 
           <div class="col-sm-4 col-md-3">
           <label for="due_diligience_incomplete"><Card class="card--filter colour-danger card--flag" data-total="" data-query="SLA progress == Overdue">Due/Overdue</Card></label>
@@ -152,7 +140,9 @@
         </div>
 
         <dialog id="filters">
+          <AppliedFilters class="applied-filters--compact" data-nosubmit>
           <span class="h3 pb-2">Filter by</span>
+
           <span class="h4 pb-1 ">Risk Level</span>
           <div>
             <input type="checkbox" name="risk-level-high" id="risk-level-high" data-filter-text="Risk Level - High" data-filter="Risk level" value="High">
@@ -166,8 +156,24 @@
             <label for="risk-level-low" class="form-label form-check-label">Low</label>
             <hr/>
           </div>
-          <button class="btn btn-primary d-block m-auto">Update results</button>
+
+          <span class="h4 pb-1 ">SLA Progress</span>
+          <div>
+            <input type="checkbox" name="[sla_progress][]" id="sla_progress_due" data-filter-text="SLA progress - Due" value="Due" data-duplicate="due_diligience_incomplete" />
+            <label for="sla_progress_due">Due</label>
+            <hr/>
+            <input type="checkbox" name="[sla_progress][]" id="sla_progress_upcoming" data-filter-text="SLA progress - Upcoming" value="Upcoming" data-duplicate="due_diligience_requires_approval"/>
+            <label for="sla_progress_upcoming">Upcoming</label>
+            <hr/>
+
+            <input type="checkbox" name="[sla_progress][]" id="sla_progress_track" data-filter-text="SLA progress - On track" value="track" data-duplicate="due_diligience_verified" />
+            <label for="sla_progress_track">On track</label>
+            <hr/>
+          </div>
+          </AppliedFilters>
+          <button class="btn btn-primary d-block mx-auto">Update results</button>
           <hr/>
+
         </dialog>
 
       </form>


### PR DESCRIPTION
## Summary of Changes
1. Allow for duplicate filter cards
2. Fix clear filters 

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /standalone/compliance-dashboard

## Ticket(s)
FEG-258

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
