### PR TITLE
Add the ability to remove dark mode

### DIFF
--- a/assets/sass/_corefiles.scss
+++ b/assets/sass/_corefiles.scss
@@ -20,7 +20,6 @@
 @use "components/admin-panel.scss";
 @use "components/dialog.scss";
 
-@use "components/nav-global.scss";
 @use "components/pagination.scss";
 @use "components/accordion.scss";
 

--- a/assets/sass/_func.scss
+++ b/assets/sass/_func.scss
@@ -1,5 +1,6 @@
 $compatible: 'false'!default;
 $mobileOnly: 'false'!default;
+$darkMode: 'true'!default;
 
 // Declare global vars variable
 $vars: ()!default;

--- a/assets/sass/_functions/mixins.scss
+++ b/assets/sass/_functions/mixins.scss
@@ -18,6 +18,28 @@
   }
 }
 
+@mixin dark-mode(){
+  @media screen and (prefers-color-scheme: dark) {
+    @if $darkMode == "true" {
+        
+      @content;
+    }
+  }
+}
+
+@mixin light-mode(){
+
+  @if $darkMode == "true" {
+    @media screen and (prefers-color-scheme: light) {
+    
+      @content;
+    }
+  }
+  @else {
+    @content;
+  }
+}
+
 @mixin container-up($name) {
   
   @if $name == 'sm' {

--- a/assets/sass/components/admin-panel.scss
+++ b/assets/sass/components/admin-panel.scss
@@ -12,7 +12,7 @@
   margin-bottom: rem(24);
   outline: var(--contrast-outline-width, 0px) solid var(--colour-primary);
 
-  @media screen and (prefers-color-scheme: dark) {
+  @include dark-mode() {
     
     background-color: var(--colour-canvas-2);
     color: var(--colour-body);

--- a/assets/sass/components/card.scss
+++ b/assets/sass/components/card.scss
@@ -211,7 +211,7 @@
   }
 }
 
-@media screen and (prefers-color-scheme: dark) {
+@include dark-mode() {
   .card--filter {
 
     .card__body {

--- a/assets/sass/components/charts.scss
+++ b/assets/sass/components/charts.scss
@@ -22,7 +22,7 @@ $chart-colors: map-merge((
   }
 }
 
-@media screen and (prefers-color-scheme: dark) {
+@include dark-mode() {
 
   :root {
     --colour-chart-1: var(--colour-dark);

--- a/assets/sass/components/collapsible-side.scss
+++ b/assets/sass/components/collapsible-side.scss
@@ -4,7 +4,7 @@
   --colour-border: #e9e9e9;
   --side-link-hover: var(--colour-canvas-2);
 
-  @media screen and (prefers-color-scheme: light) {
+  @include light-mode() {
             
     --side-link-hover: #eeeeee;
   }

--- a/assets/sass/components/dialog.scss
+++ b/assets/sass/components/dialog.scss
@@ -374,7 +374,7 @@ dialog::backdrop {
       }
     }
 
-    @media screen and (prefers-color-scheme: dark) {
+    @include dark-mode() {
 
       button {
         

--- a/assets/sass/components/fileupload.scss
+++ b/assets/sass/components/fileupload.scss
@@ -53,7 +53,7 @@
 
 
     
-    @media screen and (prefers-color-scheme: dark) {
+    @include dark-mode() {
 
       background: var(--colour-canvas-2);
       border-color: var(--colour-canvas-2);

--- a/assets/sass/components/nav-global.scss
+++ b/assets/sass/components/nav-global.scss
@@ -165,7 +165,7 @@ iam-nav details {
 
     background-color: var(--colour-canvas);
     
-    @media screen and (prefers-color-scheme: light) {
+    @include light-mode() {
       background-color: #EEEEEE;
     }
 
@@ -180,9 +180,9 @@ iam-nav details {
       background-color: var(--colour-white);
 
             
-      @media screen and (prefers-color-scheme: dark) {
+      @include dark-mode() {
         
-      background-color: var(--colour-canvas-2);
+        background-color: var(--colour-canvas-2);
       }
       display:block;
       border: none;
@@ -378,11 +378,11 @@ iam-nav details {
       box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.11);
 
       
-      @media screen and (prefers-color-scheme: light) {
+      @include light-mode() {
         background: var(--colour-white);
         @include reset-colours();
       }
-      @media screen and (prefers-color-scheme: dark) {
+      @include dark-mode() {
 
         @include invert-colours();
       }
@@ -393,7 +393,7 @@ iam-nav details {
       
       background: var(--colour-canvas-2);
       
-      @media screen and (prefers-color-scheme: light) {
+      @include light-mode() {
         background: #EEEEEE;
       }
       a {
@@ -426,7 +426,7 @@ iam-nav details {
     &[open] > div:not(:has(details)) {
       background: var(--colour-canvas);
 
-      @media screen and (prefers-color-scheme: light) {
+      @include light-mode() {
         background: var(--colour-white);
         --colour-canvas-2: white;
       }

--- a/assets/sass/components/nav.scss
+++ b/assets/sass/components/nav.scss
@@ -98,7 +98,7 @@
     }
 
     .btn {
-      @media screen and (prefers-color-scheme: light) {
+      @include light-mode() {
     
         @include reset-colours();
 
@@ -188,13 +188,13 @@
       flex-shrink: 0;
     }
 
-    @media screen and (prefers-color-scheme: dark) {
+    @include dark-mode() {
       --colour-link: var(--colour-white);
       @include invert-colours();
     }
 
     // The menu is always white unless in dark mode
-    @media screen and (prefers-color-scheme: light) {
+    @include light-mode() {
       
       background-color: var(--colour-white);
       @include reset-colours();
@@ -242,7 +242,7 @@
     flex-grow: 1;
     position: relative;
 
-    @media screen and (prefers-color-scheme: light) {
+    @include light-mode() {
       background-color: #EEEEEE;
     }
 
@@ -393,14 +393,13 @@
     left: 0;
     width: 100%;
 
-    @media screen and (prefers-color-scheme: light) {
+    @include light-mode(){
             
       background-color: #EEEEEE;
       @include reset-colours();
     }
 
-    @media screen and (prefers-color-scheme: dark) {
-            
+    @include dark-mode() {
       
       @include invert-colours();
     }
@@ -494,7 +493,7 @@
 
     background: #E6EAEC!important;
 
-    @media screen and (prefers-color-scheme: dark) {
+    @include dark-mode() {
       
       background: var(--colour-canvas-2)!important;
     }
@@ -564,13 +563,13 @@
     flex-shrink: 0;
   }
 
-  @media screen and (prefers-color-scheme: dark) {
+  @include dark-mode() {
     --colour-link: var(--colour-white);
     @include invert-colours();
   }
 
   // The menu is always white unless in dark mode
-  @media screen and (prefers-color-scheme: light) {
+  @include light-mode() {
     
     background-color: var(--colour-white);
     @include reset-colours();

--- a/assets/sass/components/notification.scss
+++ b/assets/sass/components/notification.scss
@@ -90,7 +90,7 @@
   display: flex;
   flex-wrap: nowrap;
 
-  @media screen and (prefers-color-scheme: light) {
+  @include light-mode() {
     color: var(--colour-heading);
   }
 

--- a/assets/sass/core.scss
+++ b/assets/sass/core.scss
@@ -2,5 +2,6 @@
 
 @use "_fonts";
 @use "_corefiles";
+@use '../../assets/sass/components/nav-global.scss';
 @use "_forms";
 @use "_print";

--- a/assets/sass/error.scss
+++ b/assets/sass/error.scss
@@ -3,3 +3,4 @@
 // Set mobile only variable so that the media query mixin doesn't print out non mobile rules
 @use "_func" as *;
 @import "_corefiles";
+@import '../../assets/sass/components/nav-global.scss';

--- a/assets/sass/foundations/root.scss
+++ b/assets/sass/foundations/root.scss
@@ -39,7 +39,7 @@
 }
 
 // Dark mode; functional colours get updated
-@media screen and (prefers-color-scheme: dark) {
+@include dark-mode() {
   :root {
     
     @each $color, $value in $dark-mode-colors {
@@ -49,7 +49,7 @@
   }
 }
 
-@media screen and (prefers-color-scheme: light) {
+@include light-mode() {
 
   // Reset the colours of lighter backgrounds to make sure they aren't over written by dark mode. Some other tweaks to colours are applied
   [class*="bg-"]:not(.bg-primary):not(.bg-dark):not(.bg-danger):not(.bg-white):not(.bg-canvas):not(.bg-canvas-2):not(.invert-colours) {
@@ -72,7 +72,7 @@
   }
 }
 
-@media screen and (prefers-color-scheme: dark) {
+@include dark-mode() {
 
   // Reset the colours of lighter backgrounds to make sure they aren't over written by dark mode. Some other tweaks to colours are applied
   [class*="bg-"]:not(.bg-canvas):not(.bg-canvas-2) {

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -3,6 +3,6 @@
 @use "_fonts";
 @use "_corefiles";
 @import '../../assets/sass/components/nav-global.scss';
-@use "_forms";
-@use "_components";
-@use "_print";
+@import "_forms";
+@import "_components";
+@import "_print";

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -2,6 +2,7 @@
 
 @use "_fonts";
 @use "_corefiles";
+@import '../../assets/sass/components/nav-global.scss';
 @use "_forms";
 @use "_components";
 @use "_print";

--- a/docs/assets/styles.scss
+++ b/docs/assets/styles.scss
@@ -4,6 +4,7 @@
 $fontPath: '../../fonts/';
 @import "../../assets/sass/_fonts.scss";
 @import '../../assets/sass/_corefiles.scss';
+@import '../../assets/sass/components/nav-global.scss';
 @import "../../assets/sass/_forms";
 
 


### PR DESCRIPTION
## Summary of Changes
1. Add the ability to remove dark mode support

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
N/A

## Ticket(s)
FEG-261

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
