### PR TITLE
FEG-35-Feature-Using-CSS-to-Enforce-Accessibility

### DIFF
--- a/assets/sass/components/collapsible-side.scss
+++ b/assets/sass/components/collapsible-side.scss
@@ -96,16 +96,27 @@
     background-color: var(--colour-canvas-2);
     border: 2px solid var(--colour-border);
     z-index: 99;
+    
+    &[aria-expanded]{
+       // Change icon
+      &[class*=fa-]:before {
+        content: "\f053"!important;
+      }
+
+      @include media-breakpoint-up(md) {
+        opacity: 0;
+        transition: opacity 0.5s;
+
+        &:is(:hover,:focus,:active) {
+          opacity: 1;
+        }
+      }
+    }
   }
 
   &:is(.open) {
 
     width: calc(100% - var(--container-padding-x));
-
-    // Change icon
-    .btn[class*=fa-]:before {
-      content: "\f053"!important;
-    }
 
     @include media-breakpoint-up(sm) {
 
@@ -114,15 +125,6 @@
     @include media-breakpoint-up(md) {
 
       width: rem(344);
-
-      .btn {
-        opacity: 0;
-        transition: opacity 0.5s;
-
-        &:is(:hover,:focus,:active) {
-          opacity: 1;
-        }
-      }
     }  
   }
 
@@ -233,7 +235,7 @@
   */
 }
 
-::slotted(a[slot="menu"]:where(:hover,:focus,.selected)) {
+::slotted(a[slot="menu"]:where(:hover,:focus,[aria-expanded])) {
 
   background-color: var(--side-link-hover)!important;
 }
@@ -244,7 +246,7 @@
   font-weight: bold!important;
 }
 
-::slotted(a[slot="menu"].selected) {
+::slotted(a[slot="menu"][aria-expanded]) {
 
   background-color: var(--side-link-hover)!important;
   font-weight: bold!important;

--- a/assets/sass/components/dialog.scss
+++ b/assets/sass/components/dialog.scss
@@ -551,15 +551,10 @@ dialog::backdrop {
       transform: rotate(90deg);
     }
 
-    &.active:after {
+    &[aria-expanded]:after {
 
-      transform: rotate(-90deg);
+      transform: rotate(270deg);
     }
-  }
-
-  &:has(dialog[open]) > .btn:first-child:after {
-
-    transform: rotate(270deg);
   }
 
   > dialog[open] {

--- a/assets/sass/components/forms.scss
+++ b/assets/sass/components/forms.scss
@@ -349,19 +349,19 @@ input[maxlength] + span {
 // #region Form validation
 
 
-.was-validated *:not(button):is(:invalid, .is-invalid):not(.is-valid) + label,
-.was-validated label:has(*:not(button):is(:invalid, .is-invalid):not(.is-valid)) {
+.was-validated *:not(button):is(:invalid, .is-invalid, [aria-invalid]):not(.is-valid) + label,
+.was-validated label:has(*:not(button):is(:invalid, .is-invalid, [aria-invalid]):not(.is-valid)) {
 
   --colour-check-border: var(--colour-danger);
   --colour-check-bg: #FCEBEC;
   border-color: var(--colour-danger);
 }
 
-.was-validated *:not(button):is(:invalid, .is-invalid,:-internal-autofill-selected) {
+.was-validated *:not(button):is(:invalid, .is-invalid, [aria-invalid],:-internal-autofill-selected) {
 
   border-color: var(--colour-danger)!important;
 }
-.was-validated input:is(:invalid, .is-invalid,:-internal-autofill-selected) {
+.was-validated input:is(:invalid, .is-invalid,[aria-invalid],:-internal-autofill-selected) {
 
   background-image: escape-svg($icon-error);
   background-repeat: no-repeat;

--- a/assets/sass/components/nav-global.scss
+++ b/assets/sass/components/nav-global.scss
@@ -121,7 +121,7 @@ iam-nav {
     
     text-decoration: none;
 
-    &:where(:hover,:focus,.selected) {
+    &:where(:hover,:focus,.selected,[aria-current="page"]) {
       text-decoration: underline;
       text-underline-offset: 0.3em;
       text-decoration-thickness: 2px;
@@ -130,8 +130,8 @@ iam-nav {
     &:active {
       text-decoration-color: #A2D393!important;
     }
-    &.selected {
-      
+    &.selected,
+    &[aria-current="page"] {
       text-decoration-color: var(--colour-info)!important;
     }
   }
@@ -506,7 +506,7 @@ iam-nav details {
       display: block;
       margin: 0;
       
-      &:where(:hover,:focus,.selected) {
+      &:where(:hover,:focus,.selected,[aria-current="page"]) {
         text-decoration: underline;
         text-underline-offset: 0.3em;
         text-decoration-thickness: 2px;
@@ -515,7 +515,8 @@ iam-nav details {
       &:active {
         text-decoration-color: #A2D393!important;
       }
-      &.selected {
+      &.selected,
+      &[aria-current="page"] {
         text-decoration-color: var(--colour-info);
       }
 

--- a/assets/sass/components/nav.scss
+++ b/assets/sass/components/nav.scss
@@ -46,7 +46,7 @@
     display: none;
   }
 
-  &.selected {
+  &[aria-expanded] {
 
     i {
       display: none;
@@ -79,7 +79,7 @@
     padding-right: rem(24 + 6);
     text-indent: 0;
 
-    &.selected {
+    &[aria-expanded] {
       text-indent: -1000%;
     }
   }
@@ -93,7 +93,7 @@
     text-indent: 0;
     padding-right: 0!important;
 
-    &.selected {
+    &[aria-expanded] {
       text-indent: 0;
     }
 
@@ -227,7 +227,7 @@
       display: none!important;
     }
   }
-
+  
   .menu__secondary {
     display: none;
   }

--- a/assets/sass/components/stepper.scss
+++ b/assets/sass/components/stepper.scss
@@ -113,7 +113,7 @@
           text-indent: -0.1em;
         }
 
-        &.current {
+        &[aria-current="step"] {
           background: var(--colour-primary);
           color: white;
           pointer-events: none;

--- a/assets/sass/components/table.extras.scss
+++ b/assets/sass/components/table.extras.scss
@@ -33,6 +33,10 @@ iam-table {
       }
     }
   }
+
+  &[data-expandable] [data-expand-button][aria-expanded] {
+    background-color: transparent;
+  }
 }
 // #endregion
 
@@ -143,11 +147,10 @@ iam-table {
         font-weight: 300!important;
         font-size: rem(28);
         line-height: var(--compact-size)!important;
+      
       }
-    }
 
-    tr[data-view="full"] {
-      [data-expand-button] {
+      &[aria-expanded]{
 
         &:before {
             
@@ -391,7 +394,7 @@ iam-table table:not(.table--filtered):not(.table--ajax) tbody tr:nth-child(15) ~
 
 iam-table {
 
-  input:is([type="radio"],[type="checkbox"]) + label {
+  input:is([type="radio"],[type="checkbox"]) + label:not(.radio--tick) {
     padding-left: 0!important;
     margin: 0!important;
 
@@ -443,7 +446,7 @@ iam-table {
 
   iam-table {
 
-    input:is([type="radio"],[type="checkbox"]) + label {
+    input:is([type="radio"],[type="checkbox"]) + label:not(.radio--tick) {
       padding-left: 0!important;
       margin: 0!important;
       min-height: 2rem;
@@ -502,16 +505,15 @@ iam-table.table--fullwidth:not([data-expandable]) {
         content: "\f078";
         font-weight: 500;
       }
+
+      &[aria-expanded]{
+        &:before {
+          content: "\f077";
+        }
+      }
     }
 
-    tr[data-view="full"] [data-expand-button]:before {
-    
-      content: "\f077";
-    }
-
-    tr:not([data-view="full"]) td p {
-
-      
+    tr:not([data-view="full"]) td p {   
       display: -webkit-box;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 2;

--- a/assets/sass/foundations/buttons.scss
+++ b/assets/sass/foundations/buttons.scss
@@ -266,7 +266,7 @@ a:is(:hover, :focus, .hover, :active, .active):not([disabled]) .btn-secondary,
     }
   }
 
-  &.btn-secondary:is(:hover, :focus, .hover, :active, .active, :focus-within):not([disabled]) {
+  &.btn-secondary:is(:hover, :focus, .hover, :active, .active, [aria-expanded], :focus-within):not([disabled]) {
     background-color: var(--colour);
     color: var(--colour-primary-theme);
     border-color: transparent!important;

--- a/assets/ts/components/actionbar/actionbar.component.ts
+++ b/assets/ts/components/actionbar/actionbar.component.ts
@@ -213,10 +213,13 @@ class iamActionbar extends HTMLElement {
     if(this.hasAttribute('data-search') && this.getAttribute('data-search') == 'show')
       searchBar.classList.add('show');
 
+      const searchBtn = this.shadowRoot.querySelector('button[data-search]');      
+
     this.shadowRoot.addEventListener('click', (event) => {
 
       if (event && event.target instanceof HTMLElement && event.target.closest('button[data-search]')){
         searchBar.classList.toggle('show');
+        searchBtn.toggleAttribute('aria-expanded');
       }
     });
 

--- a/assets/ts/components/collapsible-side/collapsible-side.component.ts
+++ b/assets/ts/components/collapsible-side/collapsible-side.component.ts
@@ -74,9 +74,9 @@ class iamCollapsibleSideMenu extends HTMLElement {
 
         sideMenuContent.classList.remove('closed');
 
-
         setTimeout(function(){ 
           sideMenu.classList.add('open'); 
+          button.setAttribute('aria-expanded', true);
         }, 100);
 
 
@@ -84,6 +84,8 @@ class iamCollapsibleSideMenu extends HTMLElement {
       else {
           
         sideMenu.classList.remove('open');
+        button.removeAttribute('aria-expanded');
+
         setTimeout(function(){ sideMenuContent.classList.add('closed') }, 1000); // Delay until its close so the animation is broken
       
         // While the menu is closing dont allow the hover to re-open it until its fully closed.

--- a/assets/ts/components/nav/nav.component.ts
+++ b/assets/ts/components/nav/nav.component.ts
@@ -97,7 +97,7 @@ class iamNav extends HTMLElement {
 
         // If open we need to make sure the main mobile menu is closed, the new button has the right state and the backdrop is shown
         if(element.classList.contains('open')){
-          button.classList.add('selected');
+          button.setAttribute('aria-expanded', true);
           mdButton.classList.toggle('active');
           iamNav.classList.add('open');
           backdrop.classList.add('show');
@@ -110,7 +110,7 @@ class iamNav extends HTMLElement {
         button.addEventListener('click', function(e){
       
           e.preventDefault();
-          button.classList.toggle('selected');
+          button.toggleAttribute('aria-expanded');
           element.classList.toggle('open');
           mdButton.classList.toggle('active');
 
@@ -124,7 +124,7 @@ class iamNav extends HTMLElement {
           if(element.classList.contains('open')){
             
             menu.classList.remove('open');
-            menuButton.classList.remove('selected');
+            menuButton.removeAttribute('aria-expanded');
             setTimeout(function(){ menu.classList.add('closed') }, 1000); // Delay until its close so the animation is broken
             iamNav.classList.add('open');
             backdrop.classList.add('show');
@@ -143,11 +143,11 @@ class iamNav extends HTMLElement {
             }
           });
 
-          iamNav.shadowRoot.querySelectorAll('.buttons-holder .btn-menu.selected').forEach(function(selectedButton){
+          iamNav.shadowRoot.querySelectorAll('.buttons-holder .btn-menu[aria-expanded]').forEach(function(selectedButton){
 
             if(selectedButton != button){
 
-              selectedButton.classList.remove('selected');
+              selectedButton.removeAttribute('aria-expanded');
               let innerBtn = selectedButton.querySelector('.btn-primary');
               innerBtn.classList.remove('active');
             }
@@ -169,7 +169,7 @@ class iamNav extends HTMLElement {
     menuButton.addEventListener('click', function(e){
       
       e.preventDefault();
-      menuButton.classList.toggle('selected');
+      menuButton.toggleAttribute('aria-expanded');
       menu.classList.toggle('open');
 
       // Close any other menus
@@ -177,8 +177,8 @@ class iamNav extends HTMLElement {
         element.classList.remove('open');
         setTimeout(function(){ element.classList.add('closed') }, 1000);
       });
-      iamNav.shadowRoot.querySelectorAll('.buttons-holder .btn-menu.selected').forEach(function(element){
-        element.classList.remove('selected');
+      iamNav.shadowRoot.querySelectorAll('.buttons-holder .btn-menu[aria-expanded]').forEach(function(element){
+        element.removeAttribute('aria-expanded');
         let innerBtn = element.querySelector('.btn-primary');
         innerBtn.classList.remove('active');
       });
@@ -197,7 +197,7 @@ class iamNav extends HTMLElement {
     // Allow outside JS to close the menu
     this.addEventListener("request-close", (event) => {
 
-      menuButton.classList.remove('selected');
+      menuButton.removeAttribute('aria-expanded');
       menu.classList.remove('open');
       iamNav.classList.remove('open');
     });
@@ -213,8 +213,8 @@ class iamNav extends HTMLElement {
       iamNav.querySelectorAll('.nav--menu.open').forEach(function(element){
         element.classList.remove('open');
       });
-      iamNav.shadowRoot.querySelectorAll('.buttons-holder .btn-menu.selected').forEach(function(element){
-        element.classList.remove('selected');
+      iamNav.shadowRoot.querySelectorAll('.buttons-holder .btn-menu[aria-expanded]').forEach(function(element){
+        element.removeAttribute('aria-expanded');
         let innerBtn = element.querySelector('.btn-primary');
         innerBtn.classList.remove('active');
       });
@@ -243,8 +243,8 @@ class iamNav extends HTMLElement {
             element.classList.remove('open');
             setTimeout(function(){ menu.classList.add('closed') }, 1000);
           });
-          iamNav.shadowRoot.querySelectorAll('.buttons-holder .btn-menu.selected').forEach(function(element){
-            element.classList.remove('selected');
+          iamNav.shadowRoot.querySelectorAll('.buttons-holder .btn-menu[aria-expanded]').forEach(function(element){
+            element.removeAttribute('aria-expanded');
             let innerBtn = element.querySelector('.btn-primary');
             innerBtn.classList.remove('active');
           });
@@ -285,7 +285,7 @@ class iamNav extends HTMLElement {
       let searchWrapper = this.shadowRoot.querySelector('#search-wrapper');
 
       searchWrapper.classList.remove('d-none');
-      searchWrapper.insertAdjacentHTML('afterbegin',`<button class="btn btn-secondary btn-compact fa-search me-0 mb-0" id="search-button">Open Search field</button>
+      searchWrapper.insertAdjacentHTML('afterbegin',`<button class="btn btn-secondary btn-compact fa-search me-0 mb-0" id="search-button" aria-controls="search-dialog">Open Search field</button>
       <dialog id="search-dialog">
       <div class="container">
         <form action="${this.hasAttribute('data-search') ? this.getAttribute('data-search') : ''}" class="row" id="search-form">
@@ -295,7 +295,7 @@ class iamNav extends HTMLElement {
             <input type="search" class="" id="search" name="search" required="" autocomplete="off" data-list="${this.hasAttribute('data-list') ? this.getAttribute('data-list') : ''}" />
           </div>
           <div class="col d-none d-md-block mw-fit-content ms-3">
-            <button class="btn btn-compact btn-secondary fa-xmark-large m-0 mb-0" type="button" id="search-close"></button>
+            <button class="btn btn-compact btn-secondary fa-xmark-large m-0 mb-0" type="button" id="search-close">Close search field</button>
           </div>
         </form>
       </div>
@@ -311,18 +311,24 @@ class iamNav extends HTMLElement {
         
         searchDialog.setAttribute('open','open');
         this.classList.add('search-open');
+
+        searchButton.setAttribute('aria-expanded', true);
       }
 
       searchButton.addEventListener("click", (event) => {
 
         searchDialog.setAttribute('open','open');
         this.classList.add('search-open');
+
+        searchButton.setAttribute('aria-expanded', true);
       });
 
       searchClose.addEventListener("click", (event) => {
 
         searchDialog.removeAttribute('open');
         this.classList.remove('search-open');
+
+        searchButton.removeAttribute('aria-expanded');
       });
 
       // Search events

--- a/assets/ts/modules/carousel.ts
+++ b/assets/ts/modules/carousel.ts
@@ -9,7 +9,7 @@ function carousel(carouselElement) {
   let smCols = carouselElement.getAttribute('data-sm-cols');
   let mdCols = carouselElement.getAttribute('data-md-cols');
 
-  carouselElement.querySelector('.carousel__controls a').classList.add('active');
+  carouselElement.querySelector('.carousel__controls a').setAttribute('aria-current', true);
 
   // On scroll we need to make sure the buttons get corrected and the next testimonial is shown
   carouselInner.addEventListener('scroll', function(e){
@@ -23,10 +23,10 @@ function carousel(carouselElement) {
       let lastItemOffset = carouselElement.querySelector('.carousel__item:last-child').offsetLeft;
 
       Array.from(carouselElement.querySelectorAll('.carousel__controls a')).forEach((link, index) => {
-        link.classList.remove('active');
+        link.removeAttribute('aria-current');
       });
 
-      carouselElement.querySelector('.control-'+targetSlide).classList.add('active');
+      carouselElement.querySelector('.control-'+targetSlide).setAttribute('aria-current', true);
       
       // Disable the previous button
       if(targetSlide == 1)
@@ -53,9 +53,9 @@ function carousel(carouselElement) {
         e.preventDefault();
 
         Array.from(carouselElement.querySelectorAll('.carousel__controls a')).forEach((link, index) => {
-          link.classList.remove('active');
+          link.removeAttribute('aria-current');
         });
-        target.classList.add('active');
+        target.setAttribute('aria-current', true);
 
         const el = document.querySelector(target.getAttribute('href'));
 

--- a/assets/ts/modules/dialogs.ts
+++ b/assets/ts/modules/dialogs.ts
@@ -139,7 +139,7 @@ const extendDialogs = (body) => {
 
       // Remove active class from exiting active buttons
       Array.from(document.querySelectorAll('.dialog__wrapper > button')).forEach((btnElement,index) => {
-        btnElement.classList.remove('active');
+        btnElement.removeAttribute('aria-expanded');
       });
 
       if(popover.hasAttribute('open')){
@@ -148,13 +148,13 @@ const extendDialogs = (body) => {
         dataEvent = "closePopover"
 
         popover.removeAttribute('style');
-        btn.classList.remove('active');
+        btn.removeAttribute('aria-expanded');
       }
       else {
         
         popover.show();
-        btn.classList.add('active');
-      
+        btn.setAttribute('aria-expanded', true);
+
         var position = btn.getBoundingClientRect();
         let topOffset = position.top;
         let leftOffset = position.left;
@@ -205,7 +205,7 @@ const extendDialogs = (body) => {
         document.querySelector('.dialog__wrapper:not([data-keep-open]) > dialog[open]').close();
 
       Array.from(document.querySelectorAll('.dialog__wrapper:not([data-keep-open]) > button')).forEach((btnElement,index) => {
-        btnElement.classList.remove('active');
+        btnElement.removeAttribute('aria-expanded');
       });
     }
   });

--- a/assets/ts/modules/table.ts
+++ b/assets/ts/modules/table.ts
@@ -78,10 +78,10 @@ export const createMobileButton = (table, wrapper) => {
   });
 
   Array.from(table.querySelectorAll('tbody tr')).forEach((row,index) => {
-        
+    const preExpanded = row.getAttribute('data-view') === 'full' ? 'aria-expanded' : '';
     row.insertAdjacentHTML(
       'afterbegin',
-      `<td class="td--fixed td--expand"><button class="btn btn-compact btn-secondary" data-expand-button>Expand</button></td>`
+      `<td class="td--fixed td--expand"><button class="btn btn-compact btn-secondary" data-expand-button ${preExpanded}>Expand</button></td>`
     );
   });
 
@@ -97,12 +97,14 @@ export const addTableEventListeners = (table) => {
       let button = event.target.closest('[data-expand-button]');
       let tableRow = button.closest('tr');
 
+      button.toggleAttribute('aria-expanded');
+
       if(tableRow.getAttribute('data-view') == "full")
         tableRow.setAttribute('data-view','default');
       else
         tableRow.setAttribute('data-view','full');
 
-        button.blur();
+      button.blur();
     };
   });
 }

--- a/audit.json
+++ b/audit.json
@@ -1,10 +1,10 @@
 {
-  "css_size": "240kb",
-  "css_core_size": "173kb",
-  "js_size": "64kb",
-  "logo_size": "24kb",
+  "css_size": "260kb",
+  "css_core_size": "188kb",
+  "js_size": "69kb",
+  "logo_size": "25kb",
   "img_size": "9kb",
-  "img_count": 1,
+  "img_count": 2,
   "fonts_size": "43kb",
   "fonts_count": 2
 }

--- a/docs/views/standalone/crm-ias/Page2.vue
+++ b/docs/views/standalone/crm-ias/Page2.vue
@@ -18,13 +18,13 @@
 
         <h3 class="h4">Payment routes</h3>
         <div class="row">
-          <div class="col-3"><img src="/img/estate-agents.png" alt="" class="mb-3"/></div>
+          <div class="col-3"><img src="/img/illustrations/estate-agents.png" alt="" class="mb-3"/></div>
           <div class="col">
             <p><strong>Buyer paid route</strong><br/> Upon successful sale, the buyer will be charged a fee of: 4.20% to a minimum of £6,000.00 (This fee covers the auction and estate agent contract.)</p>
           </div>
         </div>
         <div class="row">
-          <div class="col-3"><img src="/img/estate-agents.png" alt="" class="mb-3"/></div>
+          <div class="col-3"><img src="/img/illustrations/estate-agents.png" alt="" class="mb-3"/></div>
           <div class="col">
             <p><strong>Vendor paid route</strong><br/> Upon successful sale, the vendor will be charged a fee of: 4.20% to a minimum of £6,000.00.<br/><br/>The buyer is charged a deposit, which is taken from as part-payment of the final negotiated selling price and will be deducted from the balance of the final selling price upon completion of contracts.</p>
           </div>
@@ -33,13 +33,13 @@
         
         <h3 class="h4">Auction routes</h3>
         <div class="row">
-          <div class="col-3"><img :src="estateAgents" alt="" class="mb-3"/></div>
+          <div class="col-3"><img src="/img/illustrations/estate-agents.png" alt="" class="mb-3"/></div>
           <div class="col">
             <p><strong>Modern method</strong><br/> Buyer will pay the reservation fee or deposit on the property.<br/><br/> Agree to exchange contracts and complete within 56 days of receiving draft contracts.</p>
           </div>
         </div>
         <div class="row">
-          <div class="col-3"><img :src="estateAgents" alt="" class="mb-3"/></div>
+          <div class="col-3"><img src="/img/illustrations/estate-agents.png" alt="" class="mb-3"/></div>
           <div class="col">
             <p><strong>Traditional method</strong><br/> Buyer will pay a 10% deposit against the property.<br/><br/> Immediate exchange of contracts. Complete within 28 days from exchange.</p>
           </div>

--- a/src/components/Stepper/Step.vue
+++ b/src/components/Stepper/Step.vue
@@ -1,6 +1,6 @@
 <template>
   <li>
-    <a :href="url" :class="`${status?'bg-'+status:''}${typeof current != 'undefined'?'current':''}`" :aria-current="typeof current != 'undefined'?true:false">
+    <a :href="url" :class="`${status?'bg-'+status:''}${typeof current != 'undefined'?'current':''}`" :aria-current="typeof current != 'undefined'?'step':false">
       <span><slot></slot></span>
       <em class="visually-hidden" v-if="status"> - status: {{status}}</em>
     </a>


### PR DESCRIPTION
## Summary of Changes

- Using aria-current=page to style a navigation link differently if it’s the current page. In the case of Vue, the aria-current attribute is added out of the box to the exact current router link. For non SPA examples, this would be added in the same way we add an ‘active’ class currently. 
- Added aria-expanded attribute to the trigger for the collapsible side menu in order to restyle the button depending on it’s state.
- Added aria-expanded to buttons that trigger pop-over lists to restyle the button depending on it’s state.
- Added aria-invalid to form validation CSS so that we can add this attribute when server validation has been performed to restyle the input.
- Applied the ‘selected’ navigation item styles to aria-current=”page”.
- Replaced the use of the selected class to style mobile menu buttons with aria-expanded attribute, 
- Used aria-current=”step” in stepper component to add the ‘current’ styles
- Used aria-expanded attribute to style the button used to expand table rows
- Added aria-expanded to search bar toggle when it’s open. This doesn’t control any styles as the button is hidden but does give the user an indication of what has happened.
- Replaced ‘active’ class on carousel pagination dots with aria-current attribute.
- Fix to padding on items in popover filter list

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /components/carousel
- /components/collapsible-side-menu
- /components/nav
- /components/nav-menu
- /components/stepper
- /components/tables

## Ticket(s)
FEG-35

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accessibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
