### PR TITLE
Add grid CSS to main element so we dont need container divs anymore

### DIFF
--- a/assets/sass/components/header.scss
+++ b/assets/sass/components/header.scss
@@ -1,8 +1,13 @@
 @use "../_func" as *;
 
+:host{
+  padding-top: 0!important;
+  margin-bottom: rem(32);
+}
+
 .header-banner {
   background: linear-gradient(180deg,var(--colour-secondary) 0, var(--colour-info) 100%);
-  margin-bottom: rem(32);
+
   position: relative;
   overflow: hidden;
   max-width: 100%!important;

--- a/assets/sass/elements/container.scss
+++ b/assets/sass/elements/container.scss
@@ -57,6 +57,23 @@
     }
   }
 }
+
+
+// replicate container padding-bottom
+main > .row {
+
+  padding-bottom: #{rem(16)};
+
+  &[class*="bg-"] {
+    padding-top: #{rem(48)};
+    padding-bottom: #{rem(32)};
+  }
+
+  &[class*="bg-"] + :is(.row, .container):not([class*="bg-"]) {
+
+    padding-top: #{rem(32)};
+  }
+}
 // #endregion
 
 // #region Circles

--- a/assets/sass/foundations/reboot.scss
+++ b/assets/sass/foundations/reboot.scss
@@ -141,3 +141,51 @@ details summary > * {
 details {
   width: 100%;
 }
+
+// Main grid setup to avoid having to use continaer divs
+main {
+  --padding-inline: 1.5rem;
+  --container-max-width: #{rem(1280)};
+  --full-width-start: 0;
+
+  @include media-breakpoint-up(sm) {
+    --padding-inline: 2.5rem;
+  }
+  @include media-breakpoint-up(md) {
+    --padding-inline: 5.25rem;
+    --full-width-start: calc((100% - var(--container-max-width)) / 2);
+  }
+
+  display: grid;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  
+  grid-template-columns:
+  [full-width-start] var(--full-width-start)
+  [container-start] var(--padding-inline)
+  [content-start] min(
+  100% - (var(--padding-inline) * 2),
+  calc(var(--container-max-width) - (var(--padding-inline) * 2))
+  )
+  [content-end]
+  var(--padding-inline) [container-end]
+  var(--full-width-start) [full-width-end];
+
+  &:not(:has(.container:last-child)){
+    padding-bottom: 1rem;
+  }
+}
+
+main > :not(.full-width, .container, iam-header, [class*="bg-"]) {
+  grid-column: content;
+}
+
+
+main > :is(.full-width, .container, iam-header) {
+  grid-column: container;
+}
+
+main > :is(.full-width, [class*="bg-"]) {
+  grid-column: full-width;
+}

--- a/assets/sass/templates/form.scss
+++ b/assets/sass/templates/form.scss
@@ -57,6 +57,7 @@ body:has(.template--form) {
     background-color: var(--colour-canvas-2);
     margin-bottom: 1.5rem;
     outline: var(--contrast-outline-width, 0px) solid var(--colour-primary);
+    width: 100%;
     
     @include media-breakpoint-up(sm) {
 

--- a/docs/App.vue
+++ b/docs/App.vue
@@ -128,6 +128,10 @@ footer .router-link-active {
   overflow: auto;
 }
 
+.demo {
+  grid-column: container;
+}
+
 
 </style>
 

--- a/docs/views/BestPracticeDoc.vue
+++ b/docs/views/BestPracticeDoc.vue
@@ -1,18 +1,15 @@
 <template>
   <main>
-    <div class="container">
-      <h1>Best practice</h1>
-      <p>A set of rules that should be easily followed aswell as easily tested.</p>
 
-      <ol class="tick-list">
-        <li>Only one <code>h1</code> is used on a page and it should be the first heading on the page.</li>
-        <li>Only one <code>.btn-primary</code> is used per form/page.</li>
-        <li>Bespoke CSS should use relative units and not pixels</li>
-        <li>Buttons and links should never just feature an icon</li>
-        <li>Links and headings should be understandable out of context for example; 'click me' should be replaced with 'click me to find out more about auctions'. Sometimes this is acceptable within context so a span with the class of <code>.visually-hidden</code> can be used to hide the excess text.</li>
-      </ol>
+    <h1>Best practice</h1>
+    <p>A set of rules that should be easily followed aswell as easily tested.</p>
 
-
-    </div>
+    <ol class="tick-list">
+      <li>Only one <code>h1</code> is used on a page and it should be the first heading on the page.</li>
+      <li>Only one <code>.btn-primary</code> is used per form/page.</li>
+      <li>Bespoke CSS should use relative units and not pixels</li>
+      <li>Buttons and links should never just feature an icon</li>
+      <li>Links and headings should be understandable out of context for example; 'click me' should be replaced with 'click me to find out more about auctions'. Sometimes this is acceptable within context so a span with the class of <code>.visually-hidden</code> can be used to hide the excess text.</li>
+    </ol>
   </main>
 </template>

--- a/docs/views/Changelog.vue
+++ b/docs/views/Changelog.vue
@@ -7,6 +7,7 @@
       <ul>
         <li>Tidy up and reduce the file size of the core CSS' with some CSS moved into seperate files loaded via the component associated.</li>
         <li>Developers can now add links into the tabs component to create a secondary nav component looking like the tabs</li>
+        <li>Remove the need to put content into a .container div</li>
       </ul>
 
       <h3>Breaking changes</h3>

--- a/docs/views/DSHeader.vue
+++ b/docs/views/DSHeader.vue
@@ -15,9 +15,12 @@
 .ds-header{
   position: relative;
   overflow: hidden;
-  max-width: 80rem;
+  width: 100%;
+  max-width: 100%;
   margin-left: auto;
   margin-right: auto;
+
+  grid-column: container;
   
   @media screen and (min-width: 62em){
       

--- a/docs/views/Home.vue
+++ b/docs/views/Home.vue
@@ -3,21 +3,20 @@
     <Header title="Design system <span class='text-nowrap'>& framework</span>" image="/code.jpeg">
       <p>The single source of truth which groups all the elements that will allow the iam property team to design, realize and develop great products.</p>
     </Header>
-    <div class="container">
+    
 
-      <div class="row row-cols-1 row-cols-md-3">
+    <div class="row row-cols-1 row-cols-md-3">
 
-        <div v-for="item in items">
-          <a :href="item.link">
-            <Card>
-              {{ item.title }}
-              <span v-html="item.content"></span>
-            </Card>
-          </a>
-        </div>
+      <div v-for="item in items">
+        <a :href="item.link">
+          <Card>
+            {{ item.title }}
+            <span v-html="item.content"></span>
+          </Card>
+        </a>
       </div>
-
     </div>
+
   </main>
 </template>
 

--- a/docs/views/Principles.vue
+++ b/docs/views/Principles.vue
@@ -1,20 +1,14 @@
 <template>
   <main>
-    <div class="container">
-
-      <h1>Principles</h1>
-      <p class="strapline">Basic concepts and rules to help guide us to making the correct choices.</p>
-      <ul>
-        <li class="pb-3"><strong class="text-primary d-block">Relative units:</strong> Keeping units relative means they can react and respond to their environment making them more flexibile and durable.</li>
-        <li class="pb-3"><strong class="text-primary d-block">Variables and components:</strong> Reduce the amount of repetition and improve maintainability by using variables whenever something is used more than once. </li>
-        <li class="pb-3"><strong class="text-primary d-block">'Mobile' first:</strong> Design and build with the smallest standard viewport in mind first then introduce complexity to larger viewports.</li>
-        <li class="pb-3"><strong class="text-primary d-block">HTML first:</strong> Use standard functionality that comes free with modern web browsers and only use JavaScript to progressively enhance.</li>
-        <li class="pb-3"><strong class="text-primary d-block">Accessible for all:</strong> Make sure that we do <strong>not</strong> prevent anybody from getting the most out of our systems and sites. Use tools like <a href="https://wave.webaim.org/" title="WAVE Web Accessibility Evaluation Tool">WAVE</a> and automation testing to evaluate accessibility regularly.</li>
-        <li class="pb-3"><strong class="text-primary d-block">Server friendly:</strong> Limit the number of calls to the serer of your application. Concatenate files where appropriate, only make ajax calls that would produce new valid information and lazy load assets.</li>
-      </ul>
-
-
-
-    </div>
+    <h1>Principles</h1>
+    <p class="strapline">Basic concepts and rules to help guide us to making the correct choices.</p>
+    <ul>
+      <li class="pb-3"><strong class="text-primary d-block">Relative units:</strong> Keeping units relative means they can react and respond to their environment making them more flexibile and durable.</li>
+      <li class="pb-3"><strong class="text-primary d-block">Variables and components:</strong> Reduce the amount of repetition and improve maintainability by using variables whenever something is used more than once. </li>
+      <li class="pb-3"><strong class="text-primary d-block">'Mobile' first:</strong> Design and build with the smallest standard viewport in mind first then introduce complexity to larger viewports.</li>
+      <li class="pb-3"><strong class="text-primary d-block">HTML first:</strong> Use standard functionality that comes free with modern web browsers and only use JavaScript to progressively enhance.</li>
+      <li class="pb-3"><strong class="text-primary d-block">Accessible for all:</strong> Make sure that we do <strong>not</strong> prevent anybody from getting the most out of our systems and sites. Use tools like <a href="https://wave.webaim.org/" title="WAVE Web Accessibility Evaluation Tool">WAVE</a> and automation testing to evaluate accessibility regularly.</li>
+      <li class="pb-3"><strong class="text-primary d-block">Server friendly:</strong> Limit the number of calls to the serer of your application. Concatenate files where appropriate, only make ajax calls that would produce new valid information and lazy load assets.</li>
+    </ul>
   </main>
 </template>

--- a/docs/views/foundations/Colours.vue
+++ b/docs/views/foundations/Colours.vue
@@ -7,7 +7,7 @@
 
 
     <!-- #region Light mode -->
-    <div class="light-mode">
+    <div class="light-mode full-width">
 
       <div class="container">
         <div class="row">
@@ -119,7 +119,7 @@
     <!-- #endregion Light mode -->
     
     <!-- #region Dark mode -->
-    <div class="dark-mode">
+    <div class="dark-mode full-width">
 
       <div class="container">
           

--- a/src/components/Header/Header.vue
+++ b/src/components/Header/Header.vue
@@ -25,11 +25,17 @@ export default {
     }
   },
   mounted(){
-    this.$nextTick(function () {
 
-      // Register components
-      if (!window.customElements.get('iam-header'))
-        window.customElements.define('iam-header', iamHeader);
+    this.$nextTick(function () {
+      
+      import(`../../../assets/js/components/header/header.component${import.meta.env.DEV == "development" ? '.min' : ''}.js`).then(module => {
+
+        if (!window.customElements.get(`iam-header`))
+          window.customElements.define(`iam-header`, module.default);
+
+      }).catch((err) => {
+        console.log(err.message);
+      });
     })
   }
 }


### PR DESCRIPTION
## Summary of Changes
1. Add grid CSS to main element so we dont need container divs anymore
2. Remove some container divs to check the page doesn't break
3. Minor CSS amends

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
N/A

## Ticket(s)
FEG-302

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
