### PR TITLE
FEG 315 - BUG - Using page jump link causing table content to move along a column

### DIFF
--- a/assets/ts/modules/table.ts
+++ b/assets/ts/modules/table.ts
@@ -61,20 +61,20 @@ export const getLargestLastColWidth = (table) => {
 
 export const createMobileButton = (table, wrapper) => {
 
-
-  if(wrapper.classList.contains('.table--fullwidth') && !wrapper.hasAttribute('data-expandable'))
+  if(wrapper.classList.contains('table--fullwidth') && !wrapper.hasAttribute('data-expandable'))
     return false;
 
   if(table.querySelectorAll('thead tr th').length < 4 && !wrapper.hasAttribute('data-expandable'))
     return false;
 
-
+  //If the expand column already exists we don't need to add a new one.
   Array.from(table.querySelectorAll('thead tr')).forEach((row,index) => {
-        
-    row.insertAdjacentHTML(
-      'afterbegin',
-      `<th class="th--fixed expand-button-heading"></th>`
-    );
+    if(!table.querySelectorAll('thead tr th.expand-button-heading').length){
+      row.insertAdjacentHTML(
+        'afterbegin',
+        `<th class="th--fixed expand-button-heading"></th>`
+      );    
+    }
   });
 
   Array.from(table.querySelectorAll('tbody tr')).forEach((row,index) => {
@@ -690,7 +690,7 @@ export const populateDataQueries = (table,form,wrapper) => {
   dataQueries.forEach((queryElement, index) => {
 
     let query = queryElement.getAttribute('data-query');
-    let numberOfMatchedRows: 0;
+    let numberOfMatchedRows = 0;
 
     if(query == 'total'){
       if(wrapper.hasAttribute('data-total'))
@@ -905,7 +905,7 @@ export const loadAjaxTable = async function (table, form, pagination, wrapper){
 
   let formData = new FormData(form);
   let queryString = new URLSearchParams(formData).toString();
-  let columns = table.querySelectorAll('thead tr th');
+  let columns = table.querySelectorAll('thead tr th:not(.expand-button-heading)');
   let tbody = table.querySelector('tbody');
   let ajaxURL = form.getAttribute('data-ajax');
 
@@ -983,7 +983,6 @@ export const loadAjaxTable = async function (table, form, pagination, wrapper){
           var table_row = document.createElement('tr');
 
           columns.forEach((col, index) => {
-
             let cellOutput = '';
             var table_cell  = document.createElement('td');
             // Add some data to help with the mobile layout design

--- a/audit.json
+++ b/audit.json
@@ -1,9 +1,9 @@
 {
-  "css_size": "172kb",
-  "css_core_size": "134kb",
-  "js_size": "69kb",
+  "css_size": "173kb",
+  "css_core_size": "135kb",
+  "js_size": "71kb",
   "logo_size": "25kb",
-  "img_size": "13kb",
+  "img_size": "9kb",
   "img_count": 2,
   "fonts_size": "56kb",
   "fonts_count": 3


### PR DESCRIPTION
## Summary of Changes
1. Fix to class check for table--fullwidth
2. Only add a new heading column for the expand functionality if one doesn't already exist
3. Only add a new column for each row for the initial table columns. Expand column is added separately. 

## Review
N/A The issue exists in iamsold when trying to update the design system.

## Ticket(s)
FEG-315

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
