### PR TITLE
FEG 317 - override margin bottom for pagination dropdown wrapper

### DIFF
--- a/assets/sass/components/pagination.scss
+++ b/assets/sass/components/pagination.scss
@@ -41,6 +41,10 @@
     padding-left: rem(16);
     font-weight: bold;
   }
+
+  div:has(> select){
+    margin-bottom: 0;
+  }
 }
 
 .page-jump {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "iamproperty"
   },
   "private": false,
-  "version": "5.1.0-beta6",
+  "version": "5.1.0-beta7",
   "scripts": {
     "bootstrap": "copyfiles -u 2 node_modules/bootstrap/**/* assets/bootstrap",
     "dev": "npm run copy && node local_modules/delete-assets.js && vite --host",


### PR DESCRIPTION
## Summary of Changes
1. overriding margin bottom on divs wrapping select boxes

## Review

1. Open up the preview site (see the below netlify comment below) and navigate to: /components/pagination
2. The dropdown in the page jump component will be aligned with the 'of x' text
3. The dropdown in the per page dropdown will be aligned with the '/ page' text

## Ticket(s)
FEG-317

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
