### PR TITLE
Add a password checker span

### DIFF
--- a/assets/sass/elements/forms.scss
+++ b/assets/sass/elements/forms.scss
@@ -410,6 +410,22 @@ iam-address-lookup:has([required]){
   --error-display: block;
 }
 
+// Password checker
+.pwd-checker {
+  
+  display: block;
+  background-repeat: no-repeat!important;
+  background-position: left center;
+  background-size: 1em 1em;
+  padding-left: 1.5rem!important;
+}
+.pwd-checker.invalid-feedback {
+  background-image: escape-svg($icon-error);
+}
+
+.pwd-checker:not(.invalid-feedback) {
+  background-image: escape-svg($icon-tick)!important;
+}
 // #endregion
 
 // #region radio/checkbox field 

--- a/assets/sass/elements/forms.scss
+++ b/assets/sass/elements/forms.scss
@@ -426,6 +426,9 @@ iam-address-lookup:has([required]){
 .pwd-checker:not(.invalid-feedback) {
   background-image: escape-svg($icon-tick)!important;
 }
+label:has(.pwd-checker.invalid-feedback):after {
+  display: none!important;
+}
 // #endregion
 
 // #region radio/checkbox field 

--- a/assets/ts/modules/helpers.ts
+++ b/assets/ts/modules/helpers.ts
@@ -66,6 +66,12 @@ export const addGlobalEvents = (body) => {
 
       let form = event.target;
 
+      // Reset password types
+      Array.from(form.querySelectorAll('[data-password-type]')).forEach((input,index) => {
+        input.setAttribute('type','password');
+      });
+
+
       if(form.querySelector(':invalid')){
         
         form.classList.add('was-validated');

--- a/assets/ts/modules/helpers.ts
+++ b/assets/ts/modules/helpers.ts
@@ -71,8 +71,7 @@ export const addGlobalEvents = (body) => {
         input.setAttribute('type','password');
       });
 
-
-      if(form.querySelector(':invalid')){
+      if(form.querySelector(':invalid') || form.querySelector('.pwd-checker[data-strength="1"]') || form.querySelector('.pwd-checker[data-strength="2"]')){
         
         form.classList.add('was-validated');
         event.preventDefault();

--- a/assets/ts/modules/inputs.ts
+++ b/assets/ts/modules/inputs.ts
@@ -226,6 +226,7 @@ export const checkPWDStrength = (input, check = 'no') => {
     else
       pwdChecker.classList.remove('invalid-feedback');
 
+    pwdChecker.setAttribute('data-strength',strength)
     pwdChecker.innerHTML = `Password strength: ${strengthName[strength-1]} ${extraMsg}`;
   }
 

--- a/assets/ts/modules/inputs.ts
+++ b/assets/ts/modules/inputs.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck
+import hibpCheck from '../vendor/hibp'
+
 const extendInputs = (body) => {
 
   function loadInput(){
@@ -79,6 +81,10 @@ const extendInputs = (body) => {
 
       if(input.hasAttribute('maxlength') && input.nextElementSibling)
         input.nextElementSibling.setAttribute("data-count", input.value.length);
+
+
+      if(input.hasAttribute('data-strength-checker'))
+        checkPWDStrength(input);
     }
   });
 
@@ -151,7 +157,79 @@ export const setMaxlengthVars = (input) => {
 
 export const changeType = (input,type) => {
 
+  if(input.hasAttribute('type') && input.getAttribute('type') == 'password')
+    input.setAttribute('data-password-type',true);
+
   input.setAttribute('type',type);
 }
+
+export const checkPWDStrength = (input, check = 'no') => {
+
+  const pwdChecker = document.getElementById(input.getAttribute('data-strength-checker'))
+  const password = input.value;
+  const minChars = input.hasAttribute('minlength') ? input.getAttribute('minlength') : 12;
+
+  let strength = 1;
+  let strengthName = ['Very weak', 'Weak', 'Average', 'Strong', 'Very strong'];
+  let extraMsg = '';
+
+  //has number
+  if (password.match(/(?=.*[0-9])/))
+    strength += 1;
+  // has special character
+  if (password.match(/(?=.*[!,%,&,#,$,^,*,?,_,~,<,>,])/))
+    strength += 1;
+  // has lowercase alpha
+  if (password.match(/(?=.*[a-z])/))
+    strength += 1;
+  // has uppercase alpha
+  if (password.match(/(?=.*[A-Z])/))
+    strength += 1;
+
+  if (password.length < minChars){
+    strength = 1;
+    extraMsg = `(must be at least ${minChars} characters.)`;
+  }
+    
+
+  // if the strength is above weak and above the minimum length do some kind of api call to check if its in a list of passwords
+  
+  if(strength >= 3 && check == 'no'){
+    hibpCheck(password,input);
+
+
+    input.addEventListener('hibpCheck', function (event) {
+      checkhibpCheck(event, input)
+    });
+
+    function checkhibpCheck(event, input){
+
+        if(event.detail){ // found
+          checkPWDStrength(input,'danger');
+        } else { // not found
+          checkPWDStrength(input,'success');
+        }
+
+        input.removeEventListener("hibpCheck", checkhibpCheck); // Succeeds   
+    }
+
+  }
+  else if(strength >= 3 && check == 'danger'){
+    strength = 3;
+    extraMsg = `(this password is very common)`;
+  }
+
+
+  if(pwdChecker){
+    if(strength <= 3)
+      pwdChecker.classList.add('invalid-feedback');
+    else
+      pwdChecker.classList.remove('invalid-feedback');
+
+    pwdChecker.innerHTML = `Password strength: ${strengthName[strength-1]} ${extraMsg}`;
+  }
+
+}
+
 
 export default extendInputs;

--- a/assets/ts/vendor/hibp.ts
+++ b/assets/ts/vendor/hibp.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+
+/**
+ * hibp.js
+ * @version v1
+ * @author Mehdi Bounya
+ *
+ * Report any bugs here: https://github.com/mehdibo/hibp-js
+ *
+ * The MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+function sha1(string){
+  var buffer = new TextEncoder("utf-8").encode(string);
+  return crypto.subtle.digest("SHA-1", buffer).then(function (buffer) {
+      // Get the hex code
+      var hexCodes = [];
+      var view = new DataView(buffer);
+      for (var i = 0; i < view.byteLength; i += 4) {
+          // Using getUint32 reduces the number of iterations needed (we process 4 bytes each time)
+          var value = view.getUint32(i)
+          // toString(16) will give the hex representation of the number without padding
+          var stringValue = value.toString(16)
+          // We use concatenation and slice for padding
+          var padding = '00000000'
+          var paddedValue = (padding + stringValue).slice(-padding.length)
+          hexCodes.push(paddedValue);
+      }
+      // Join all the hex strings into one
+      return hexCodes.join("");
+  });
+}
+
+const hibpCheck = (pwd,input) => {
+  // We hash the pwd first
+  sha1(pwd).then(function(hash){
+      // We send the first 5 chars of the hash to hibp's API
+      const req = new XMLHttpRequest();
+      req.addEventListener("load", function(){
+          // When we get back a response from the server
+          // We create an array of lines and loop through them
+          const resp = this.responseText.split('\n');
+          const hashSub = hash.slice(5).toUpperCase();
+          var result = false;
+          for(let index in resp){
+              // Check if the line matches the rest of the hash
+              if(resp[index].substring(0, 35) == hashSub){
+                  result = true;
+                  break; // If found no need to continue the loop
+              }
+          }
+          // Trigger an event with the result
+          const event = new CustomEvent('hibpCheck', {detail: result});
+          input.dispatchEvent(event);
+      });
+      req.open('GET', 'https://api.pwnedpasswords.com/range/'+hash.substr(0, 5));
+      req.send();
+  });
+}
+
+export default hibpCheck;

--- a/docs/views/form/FormInputDoc.vue
+++ b/docs/views/form/FormInputDoc.vue
@@ -417,7 +417,6 @@
       <p class="pb-3">Password fields hide the field value for security. We can add an optional hide/show button after the field.</p>
     </div>
     <div class="container visualtest"> 
-
       <label>Password
         <span>
           <input type="password" id="password" name="password" required autocomplete="on" minlength="8" data-strength-checker="pwdchecker1" />
@@ -425,6 +424,7 @@
         </span>
         <span id="pwdchecker1" class="pwd-checker"></span>
       </label>
+      
     </div>
 
 

--- a/docs/views/form/FormInputDoc.vue
+++ b/docs/views/form/FormInputDoc.vue
@@ -417,12 +417,18 @@
       <p class="pb-3">Password fields hide the field value for security. We can add an optional hide/show button after the field.</p>
     </div>
     <div class="container visualtest"> 
-      <div>
-        <label for="password">Input field label</label>
-        <button type="button" class="suffix fa-solid fa-eye" data-alt-class="suffix fa-solid fa-eye-slash" data-change-type="text" data-input="password"><span class="visually-hidden">Show password</span></button>
-        <input type="password" id="password" name="password" required autocomplete="on"/>
-      </div>
+
+      <label>Password
+        <span>
+          <input type="password" id="password" name="password" required autocomplete="on" minlength="8" data-strength-checker="pwdchecker1" />
+          <button type="button" class="suffix fa-solid fa-eye-slash" data-alt-class="suffix fa-solid fa-eye" data-change-type="text" data-input="password"><span class="visually-hidden">Show password</span></button>
+        </span>
+        <span id="pwdchecker1" class="pwd-checker"></span>
+      </label>
     </div>
+
+
+
     <div class="container pb-0">
       <h3 class="h6">Colour</h3>
       <p class="pb-3">Colour fields allow the user to either enter the hex colour code in the field or select a colour from the colour picker. The colour picker should default to hex code input.</p>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "iamproperty"
   },
   "private": false,
-  "version": "5.1.0-beta10",
+  "version": "5.1.0-beta11",
   "scripts": {
     "bootstrap": "copyfiles -u 2 node_modules/bootstrap/**/* assets/bootstrap",
     "dev": "npm run copy && node local_modules/delete-assets.js && vite --host",


### PR DESCRIPTION
## Summary of Changes
1. Add password checker span
2. Configurable min length with a default of 12
3. Create a point based system to rate strength
4. Check that average strength and above passwords dont get returned by the haveibeenpwned api

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /form/inputs (passwords element)

## Ticket(s)
FEG-327

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
