### PR TITLE
Fix to allow for details in the menu component

### DIFF
--- a/assets/sass/components/component.native.scss
+++ b/assets/sass/components/component.native.scss
@@ -1,6 +1,44 @@
 @use 'sass:math';
 @use "../_func" as *;
 
+iam-nav {
+  display: block;
+  padding: var(--container-padding);
+  padding-top: 1.5rem;
+  padding-bottom: 1.5rem;
+  max-width: 80rem;
+  margin-inline: auto;
+  
+  .brand {
+    font-size: rem(48);
+    height: rem(48);
+    padding: 0;
+    text-decoration: none;
+    min-width: min(var(--svg-width), 14rem);
+  }
+}
+
+@media (scripting: enabled) {
+
+  iam-nav:not(:defined) {
+
+    > *:not([slot="logo"]) {
+      display: none;
+    }
+    
+    &:not(:target) > *:not(.brand) {
+      display: none;
+    }
+
+    @include media-breakpoint-up(md) {
+      &:has([slot="secondary"]){
+        padding-top: rem(64);
+      }
+    }
+  }
+}
+
+
 // #region Undefined web components
 :is(*):not(:defined):not(iam-nav):not(iam-pagination):not(iam-carousel) {
   display: block;

--- a/assets/sass/components/nav.docs.scss
+++ b/assets/sass/components/nav.docs.scss
@@ -44,6 +44,9 @@
     max-width: calc(23.4375rem - var(--scrollbar-width));
     transition: none;
   }
+  .menu.closed * {
+    display: block !important;
+  }
 }
 
 @include media-breakpoint-up(md) {

--- a/assets/sass/components/nav.global.scss
+++ b/assets/sass/components/nav.global.scss
@@ -167,104 +167,115 @@ iam-nav details {
 
 // #endregion
 
+
 // #region mobile and tablet mega menu
+
+@mixin mobDetails() {
+  background-color: var(--colour-canvas);
+    
+  @include light-mode() {
+    background-color: #EEEEEE;
+  }
+
+  margin-left: -1.5rem;
+  margin-right: -1.5rem;
+  padding-inline: 1.5rem;
+  width: auto;
+  position: relative;
+
+  summary {
+
+    background-color: var(--colour-white);
+
+          
+    @include dark-mode() {
+      
+      background-color: var(--colour-canvas-2);
+    }
+    display:block;
+    border: none;
+    color: var(--colour-link);
+    margin: 0;
+    
+    margin-left: -1.5rem;
+    margin-right: -1.5rem;
+    padding: 1.5rem 4rem 1.5rem 1.5rem;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    min-height: 1.5rem;
+    position: relative;
+    font-weight: normal;
+
+    &:after {
+      content: "\f055";
+      display: block;
+      font-size: rem(24);
+      font-weight: 300;
+      position: absolute;
+      top: 1.5rem;
+      right: 1.5rem;
+      font-family: "Font Awesome 6 Pro";
+      line-height: 1em;
+    }
+  }
+
+  &[open] > summary:after {
+    content: "\f056";
+    font-weight: bold;
+  }
+
+  a {
+    text-decoration: none;
+    display:block;
+    border: none;
+    color: var(--colour-link);
+    margin: 0;
+    margin-left: 3rem;
+    padding: 1.5rem 0 1.5rem 0;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    min-height: 1.5rem;
+    position: relative;
+    font-weight: normal;
+
+    &:after {
+      background: var(--colour-border)!important;
+      top: calc(100% - 2px)!important;
+      width: 100%!important;
+    }
+  }
+
+  // Hide cards
+  a:has(iam-card){ 
+    display: none!important;
+  }
+
+  > div a:last-child {
+    
+    margin-bottom: 0!important;
+  }
+
+  > div a:last-child:after {
+    display: none;
+  }
+
+  &:after {
+    content: "";
+    position: absolute;
+    top: calc(100% - 2px);
+    left: 1.5rem;
+    height: 2px;
+    width: calc(100% - 3rem);
+    display: block;
+    height: 2px;
+    background-color: var(--colour-border) !important;
+  }
+}
+
 @media screen and (max-width: 62em) {
   iam-nav details {
 
-    background-color: var(--colour-canvas);
-    
-    @include light-mode() {
-      background-color: #EEEEEE;
-    }
-
-    margin-left: -1.5rem;
-    margin-right: -1.5rem;
-    padding-inline: 1.5rem;
-    width: auto;
-    position: relative;
-
-    summary {
-
-      background-color: var(--colour-white);
-
-            
-      @include dark-mode() {
-        
-        background-color: var(--colour-canvas-2);
-      }
-      display:block;
-      border: none;
-      color: var(--colour-link);
-      margin: 0;
-      
-      margin-left: -1.5rem;
-      margin-right: -1.5rem;
-      padding: 1.5rem 4rem 1.5rem 1.5rem;
-      font-size: 1rem;
-      line-height: 1.5rem;
-      min-height: 1.5rem;
-      position: relative;
-      font-weight: normal;
-
-      &:after {
-        content: "\f055";
-        display: block;
-        font-size: rem(24);
-        font-weight: 300;
-        position: absolute;
-        top: 1.5rem;
-        right: 1.5rem;
-        font-family: "Font Awesome 6 Pro";
-        line-height: 1em;
-      }
-    }
-
-    &[open] > summary:after {
-      content: "\f056";
-      font-weight: bold;
-    }
-
-    a {
-      text-decoration: none;
-      display:block;
-      border: none;
-      color: var(--colour-link);
-      margin: 0;
-      margin-left: 3rem;
-      padding: 1.5rem 0 1.5rem 0;
-      font-size: 1rem;
-      line-height: 1.5rem;
-      min-height: 1.5rem;
-      position: relative;
-      font-weight: normal;
-
-      &:after {
-        background: var(--colour-border)!important;
-        top: calc(100% - 2px)!important;
-        width: 100%!important;
-      }
-    }
-
-    // Hide cards
-    a:has(iam-card){ 
-      display: none!important;
-    }
-
-    details a:last-child:after {
-      display: none;
-    }
-
-    &:after {
-      content: "";
-      position: absolute;
-      top: calc(100% - 2px);
-      left: 1.5rem;
-      height: 2px;
-      width: calc(100% - 3rem);
-      display: block;
-      height: 2px;
-      background-color: var(--colour-border) !important;
-    }
+    @include mobDetails();
 
     // Sub details 
     details {
@@ -298,30 +309,38 @@ iam-nav details {
     }
   } 
 }
+
 // #endregion
 
 // #region tablet mega menu tweaks
-@media screen and (max-width: 62em) and (min-width: 36em) {
 
-  iam-nav details {
+@mixin tabletDetails() {
+  
+  padding-right: rem(40);
+  margin-right: rem(-40);
+
+  &:after {
+    
+    width: calc(100% - 4rem);
+  }
+  
+  summary {
+      
     padding-right: rem(40);
     margin-right: rem(-40);
 
     &:after {
       
-      width: calc(100% - 4rem);
+      right: 2.5rem;
     }
-    
-    summary {
-        
-      padding-right: 5rem;
-      margin-right: rem(-40);
+  }
+}
 
-      &:after {
-        
-        right: 2.5rem;
-      }
-    }
+@media screen and (max-width: 62em) and (min-width: 36em) {
+
+  iam-nav details {
+
+    @include tabletDetails();
   }
 
   iam-nav details details[open] + details:before {
@@ -330,11 +349,22 @@ iam-nav details {
     margin-right: rem(-40);
   }
 }
+
+@media screen and (min-width: 62em) {
+
+  iam-nav .nav--menu details {
+    
+    @include mobDetails();
+    @include tabletDetails();
+  }
+}
+
 // #endregion
 
 // #region Desktop mega menu
 @include media-breakpoint-up(md) {
-  iam-nav details {
+  iam-nav > details,
+  iam-nav *:not(.nav--menu) > details {
 
     width: auto;
 
@@ -531,7 +561,7 @@ iam-nav details {
       }
     }
 
-    > details > summary {
+    details > summary {
 
       padding-right: 0;
       background: transparent;
@@ -542,7 +572,7 @@ iam-nav details {
     }
 
     details:not(:first-child) > summary {
-      
+        
       margin-left: rem(32);
     }
   }

--- a/assets/sass/components/nav.global.scss
+++ b/assets/sass/components/nav.global.scss
@@ -76,19 +76,6 @@ nav:has(iam-nav.nav--sticky) {
 }
 // #endregion
 
-// #region before component is loaded
-iam-nav:not(:defined) {
-
-  > *:not([slot="logo"]) {
-    display: none;
-  }
-  
-  &:not(:target) > *:not(.brand) {
-    display: none;
-  }  
-}
-// #endregion
-
 // #region General styles
 iam-nav {
 

--- a/assets/sass/components/nav.scss
+++ b/assets/sass/components/nav.scss
@@ -101,10 +101,6 @@
       @include light-mode() {
     
         @include reset-colours();
-
-        &:is(:hover,:focus){
-          color: var(--colour-inverted);
-        }
       }
 
       margin: 0!important;
@@ -128,6 +124,15 @@
       }
     }
   }
+}
+
+:host(.bg-primary) .btn {
+  
+
+    &:is(:hover,:focus){
+      color: var(--colour-inverted);
+    }
+  
 }
 
 // #region mobile and tablet menu
@@ -581,11 +586,11 @@
 
   &:before {
     display: block ;
-    width: 100%;
+    width: calc(100% + 3rem);
     border-top: 2px solid var(--colour-border);
     z-index: 1;
-    padding-block: rem(24);
-    margin: 0;
+    padding: rem(24) 1.5rem;
+    margin: 0 -1.5rem;
     font-family: $headings-font-family;
     font-style: $headings-font-style;
     font-weight: $headings-font-weight;
@@ -599,6 +604,9 @@
   
       font-size: rem(map-get($heading-sizes,"h3_fs_sm"));
       line-height: rem(map-get($heading-sizes,"h3_lh_sm"));
+      margin-right: -2.5rem;
+      padding-right: 2.5rem;
+      width: calc(100% + 4rem);
     }
   }
 
@@ -606,9 +614,13 @@
     content: attr(data-title);
   }
 
+  @include media-breakpoint-up(sm) {
+
+    padding-right: 2.5rem !important;
+  }
+
   @include media-breakpoint-up(md) {
-
-
+  
     height: calc(100vh - var(--nav-height));
     top: 100%;
   }
@@ -633,6 +645,27 @@
     
     background: rgba(0,0,0,0.2);
     backdrop-filter: blur(2px);
+  }
+}
+// #endregion
+
+// region compressed nav
+@include media-breakpoint-up(md) {
+  :host(.nav--md-compressed) .buttons-holder button {
+    margin-left: 1.5rem!important;
+  }
+
+  :host(.nav--md-compressed) .btn-menu .btn i[class*=fa-] {
+    margin-right: 0.5rem !important;
+    margin-left: -0.5rem !important;
+  }
+
+  :host(.nav--md-compressed) .btn-menu .btn {
+    --btn-padding-inline: 2.5rem;
+  }
+
+  :host(.nav--md-compressed) ::slotted(a:not([slot=logo]):not([slot=secondary])){
+    margin-left: 1.5rem!important;
   }
 }
 // #endregion

--- a/assets/ts/components/nav/nav.component.ts
+++ b/assets/ts/components/nav/nav.component.ts
@@ -231,7 +231,7 @@ class iamNav extends HTMLElement {
 
       if (event && event.target instanceof HTMLElement && event.target.closest('summary')){
 
-        if(window.innerWidth > 992){
+        if(window.innerWidth > 992 && !event.target.closest('.nav--menu')){
 
           let summary = event.target.closest('summary');
           let details = summary.closest('details');

--- a/docs/views/standalone/Agent.vue
+++ b/docs/views/standalone/Agent.vue
@@ -1,90 +1,63 @@
 <template>
   <div>
-    <Nav logo="sold" class="nav--marketplace" propertylink="/standalone/marketplace" movebutlerlink="/standalone/movebutler" iamsoldlink="/standalone/agent">
-      
+    
+
+    <nav>
+    <Nav>
+      <a href="/" class="brand brand--property" slot="logo"><svg><title>iam key</title><use xlink:href="/svg/logo.svg#logo-property"></use></svg></a>
 
 
-        <span class="h6 text-muted">Services</span>
+      <a href="/">Dashboard</a>
+        <a href="/">View all stock</a>
+          <a href="/">Upload a viewing</a>
 
-      <a href="/standalone/marketplace" class="text-decoration-none mb-4 d-flex justify-content-between align-items-center">
-        <Logo id="property" class="pb-0 pe-0 fs-2"></Logo>
-        <span class="text-success">Active</span>
-      </a>
 
-      <a href="/standalone/movebutler" class="text-decoration-none mb-4 d-flex justify-content-between align-items-center">
-        <Logo id="movebutler" class="pb-0 pe-0 fs-2"></Logo>
-        <span class="text-success">Active</span>
-      </a>
+          <a href="/">Mosa leads</a>
 
-      <a href="/standalone/agent" class="text-decoration-none mb-5 d-flex justify-content-between align-items-center">
-        <Logo id="sold" class="pb-0 pe-0 fs-2"></Logo>
-        <span class="text-success">Active</span>
-      </a>
+          <a href="/">Order marketing</a>
 
-      <span class="h6 text-muted">My Branches</span>
+          <!-- <a href="/">AuctionBoost</a>Needed? -->
 
-      <form>
-      <Input type="select" id="test1" label="Today, you're at" :options="[{display:'Branch 1',value:'1'},{display:'Branch Two',value:'2'},{display:'Create new branch',value:'new'}]" data-value-if="new" data-redirect="/cp/company/branches/create"></Input>
-      </form>
+      <div class="nav--menu" data-title="My account" data-open-title="Martin Critchlow" data-icon="fa-user fa-solid" slot="menus">
+ 
+        <div>
+                <label for="test1">Active branch</label>
+                <select class="form-select" name="test1" id="test1">
+                    <option value="1">Newcastle</option>
+                    <option value="2">Two</option>
+                    <option value="2">Three</option>
+                    <option value="2">Four</option>
+                </select>
+            </div>
+            <hr class="mt-3">
+            
+        <a href="/">Agency settings</a> <!-- Edit Agent Landing Page -->
+        <a href="/">Your rewards</a>
+        <a href="/">The Success Hub</a>
 
-      <span class="h6 text-muted">Menu</span>
+        <a href="/cp/account-overview">Control panel</a>
+        
+        <a href="/">Notifications</a><!-- Need notification number? -->
 
-      <a href="/" class="nav__featured-link text-decoration-none pb-3 d-block mb-0">
-        <span class="row">
-          <span class="col mw-fit-content"><i class="icon fs-1 fa-user"></i></span>
-          <span class="col">
-            <span Class="h5 mb-1">Control panel</span>
-            <span class="text-muted small">
-              Manage your iamproperty account, branches, staff, billing and invoices
-            </span>
-          </span>
-        </span>
-      </a>
-      
-      <a href="/" class="nav__featured-link text-decoration-none pb-3 border-top pt-3 d-block mb-0">
-        <span class="row">
-          <span class="col mw-fit-content"></span>
-          <span class="col">
-            <span Class="h5 mb-1">Quick start guide & FAQ</span>
-            <span class="text-muted small">
-              Download a guide on how to manage your account
-            </span>
-          </span>
-        </span>
-      </a>
-      
-      <a href="/" class="nav__featured-link text-decoration-none pb-3 border-top pt-3 d-block mb-0">
-        <span class="row">
-          <span class="col mw-fit-content"></span>
-          <span class="col">
-            <span Class="h5 mb-1">Contact us</span>
-            <span class="text-muted small">
-              Get in touch
-            </span>
-          </span>
-        </span>
-      </a>
+        <a href="/">Quick start guide & FAQ</a><!--Footer -->
+        <a href="/">Contact us</a> <!-- What link? -->
+        <a href="/">Log out</a>
 
-      <a href="/" class="nav__featured-link text-decoration-none pb-3 border-top pt-3 d-block mb-0">
-        <span class="row">
-          <span class="col mw-fit-content"><i class="icon fs-1 fa-sign-out"></i></span>
-          <span class="col">
-            <span Class="h5 mb-1">Log out</span>
-            <span class="text-muted small">
-              Martin  Critchlow<br> Watson-Clark
-            </span>
-          </span>
-        </span>
-      </a>
+          
+      </div>
 
 
 
-      <template v-slot:secondary>
+      <a href="/" slot="secondary" >iamproperty</a>
+      <a href="https://vtopenview.com/MyDay" slot="secondary">CRM</a>
+      <a href="/" slot="secondary">movebutler</a>
+      <a href="/" slot="secondary" class="selected">iamsold</a>
 
-TBC
 
-      </template>
     </Nav>
+    </nav>
+
+
     <main class="main--marketplace">
       
       <div class="container pt-4">

--- a/docs/views/standalone/Movebutler.vue
+++ b/docs/views/standalone/Movebutler.vue
@@ -1,124 +1,73 @@
 <template>
   <div>
-    <Nav logo="movebutler" class="nav--marketplace" propertylink="/standalone/marketplace" movebutlerlink="/standalone/movebutler" iamsoldlink="/standalone/agent">
-      
 
-        <span class="h6 text-muted">Services</span>
-
-      <a href="/standalone/marketplace" class="text-decoration-none mb-4 d-flex justify-content-between align-items-center">
-        <Logo id="property" class="pb-0 pe-0 fs-2"></Logo>
-        <span class="text-success">Active</span>
-      </a>
-
-      <a href="/standalone/movebutler" class="text-decoration-none mb-4 d-flex justify-content-between align-items-center">
-        <Logo id="movebutler" class="pb-0 pe-0 fs-2"></Logo>
-        <span class="text-success">Active</span>
-      </a>
-
-      <a href="/standalone/agent" class="text-decoration-none mb-5 d-flex justify-content-between align-items-center">
-        <Logo id="sold" class="pb-0 pe-0 fs-2"></Logo>
-        <span class="text-success">Active</span>
-      </a>
-
-      <span class="h6 text-muted">My Branches</span>
-
-      <form>
-      <Input type="select" id="test1" label="Today, you're at" :options="[{display:'Branch 1',value:'1'},{display:'Branch Two',value:'2'},{display:'Create new branch',value:'new'}]" data-value-if="new" data-redirect="/cp/company/branches/create"></Input>
-      </form>
-
-      <span class="h6 text-muted">Menu</span>
-
-      <a href="/" class="nav__featured-link text-decoration-none pb-3 d-block mb-0">
-        <span class="row">
-          <span class="col mw-fit-content"><i class="icon fs-1 fa-user"></i></span>
-          <span class="col">
-            <span Class="h5 mb-1">Control panel</span>
-            <span class="text-muted small">
-              Manage your iamproperty account, branches, staff, billing and invoices
-            </span>
-          </span>
-        </span>
-      </a>
-      
-      <a href="/" class="nav__featured-link text-decoration-none pb-3 border-top pt-3 d-block mb-0">
-        <span class="row">
-          <span class="col mw-fit-content"></span>
-          <span class="col">
-            <span Class="h5 mb-1">Quick start guide & FAQ</span>
-            <span class="text-muted small">
-              Download a guide on how to manage your account
-            </span>
-          </span>
-        </span>
-      </a>
-      
-      <a href="/" class="nav__featured-link text-decoration-none pb-3 border-top pt-3 d-block mb-0">
-        <span class="row">
-          <span class="col mw-fit-content"></span>
-          <span class="col">
-            <span Class="h5 mb-1">Contact us</span>
-            <span class="text-muted small">
-              Get in touch
-            </span>
-          </span>
-        </span>
-      </a>
-
-      <a href="/" class="nav__featured-link text-decoration-none pb-3 border-top pt-3 d-block mb-0">
-        <span class="row">
-          <span class="col mw-fit-content"><i class="icon fs-1 fa-sign-out"></i></span>
-          <span class="col">
-            <span Class="h5 mb-1">Log out</span>
-            <span class="text-muted small">
-              Martin  Critchlow<br> Watson-Clark
-            </span>
-          </span>
-        </span>
-      </a>
-
-
-      <template v-slot:secondary>
-
-        <ul class="list-unstyled pt-4">
-          <li class="pb-2"><a href="/ic" class="fw-bold">Dashboard</a></li>
-          <li class="pb-2">
-              <span class="nav__title fw-bold">Transactions</span>
-              <ul class="list-unstyled ms-3">
-                <li><a href="/standalone/movebutler" >Properties</a></li>
-                <li><a href="/standalone/agent">Client Onboarding</a></li>
-                <li><a href="/props">Track Conveyancing</a></li>
-              </ul>
-          </li>
-          <li class="pb-2">
-            <span class="nav__title fw-bold">Compliance</span>
-            <ul class="list-unstyled ms-3">
-              <li><a href="http://my.iamproperty.test/ic/land-registry">Order Land Registry Documents</a></li>
-              <li><a href="http://my.iamproperty.test/ic/aml-faqs">Compliance Help Centre</a></li>
-              <li><a href="https://www.ukciu.gov.uk/(taisli55qjh4fx2l0azbvi2r)/Registration/Login.aspx" target="_blank">Report a SAR</a></li>
-              <li><a href="http://my.iamproperty.test/ic/training-library">Training Library</a></li>
-              <li><a href="https://iamproperty-core-assets.s3.eu-west-2.amazonaws.com/AML%20Policy%20Template.docx">Download Template AML Policy</a></li>
-              <li><a href="https://iamproperty-core-assets.s3.eu-west-2.amazonaws.com/movebutler/movebutler+MLO+Guide.pdf">Download Money Laundering Officer Guide</a></li>
-            </ul>
-          </li>
-          <li class="pb-2"><a href="/props" class="fw-bold">Service Marketplace</a></li>
-          <li class="pb-2">
-            <span class="nav__title fw-bold">Conveyancing</span>
-            <ul class="list-unstyled ms-3">
-              <li><a href="http://my.iamproperty.test/ic/land-registry">My Solicitors</a></li>
-              <li><a href="http://my.iamproperty.test/ic/aml-faqs">Compare Solicitors</a></li>
-            </ul>
-          </li>
-          <li class="pb-2">
-            <span class="nav__link fw-bold">Agency Settings</span>
-            <ul class="list-unstyled ms-3">
-              <li><a href="http://my.iamproperty.test/ic/land-registry">Staff Usage</a></li>
-            </ul>
-          </li>
-          <li><a href="/props" class="fw-bold">Contact Us</a></li>
-        </ul>
-
-      </template>
+    <nav>
+    <Nav class="bg-primary nav--md-compressed">
+      <a href="/" class="brand brand--property" slot="logo"><svg><title>iam key</title><use xlink:href="/svg/logo.svg#logo-property"></use></svg></a>
+        <a href="/" slot="secondary" >iamproperty</a>
+        <a href="https://vtopenview.com/MyDay" slot="secondary">CRM</a>
+        <a href="/" slot="secondary" class="selected">movebutler</a>
+        <a href="/" slot="secondary" >iamsold</a>
+        <div class="nav--menu" data-title="My account" data-open-title="Derek" data-icon="fa-user fa-solid" slot="menus">
+            <div>
+                <label for="test1">Active branch</label>
+                <select class="form-select" name="test1" id="test1">
+                    <option value="1">Newcastle</option>
+                    <option value="2">Two</option>
+                    <option value="2">Three</option>
+                    <option value="2">Four</option>
+                </select>
+            </div>
+            <hr class="mt-3">
+            
+            <details>
+        <summary>Actions</summary>
+        <div>
+        <a href="/">View all stock</a>
+          <a href="/">Upload a viewing</a>
+          <a href="/">Mosa leads</a>
+          <a href="/">AuctionBoost</a>
+          <a href="/">The Success Hub</a>
+          <a href="/">Edit Agent Landing Page</a>
+          <a href="/">Order marketing</a>
+        </div>
+      </details>
+            <a href="/cp/account-overview">Control panel</a>
+            <a href="#">Success hub</a>
+            <a href="/" class="mb-4">Your credits</a>
+ 
+            
+        </div>
+ 
+        <a href="/" class="fw-bold">Dashboard</a>
+        <a class="text-nowrap" id="riskAssessmentSideBar" href="/">Client Onboarding</a>
+ 
+        <a class="text-nowrap" id="transactionSideBar" href="/">Property Audit</a>
+ 
+ 
+        <details>
+            <summary>Compliance Support</summary>
+            <div data-title="Compliance Support">                
+                <a href="/">Order Land Registry Documents</a>
+                <a href="https://helpcentre.iamproperty.com" target="_blank">Compliance Help Centre <i class="fa-regular fa-arrow-up-right-from-square text-primary"> </i></a>
+                <a href="https://www.ukciu.gov.uk/(taisli55qjh4fx2l0azbvi2r)/Registration/Login.aspx" target="_blank">Report a SAR <i class="fa-regular fa-arrow-up-right-from-square text-primary"> </i></a>
+            </div>
+        </details>
+        <details>
+            <summary>Conveyancing</summary>
+            <div data-title="Conveyancing">                
+                    <a href="/">Conveyancing Opportunities</a>
+                <a href="/">
+                    My Solicitors
+                </a>
+                <a href="/">
+                    Compare Solicitors
+                </a>
+            </div>
+        </details>
     </Nav>
+    </nav>
+
     <main class="main--marketplace">
       
       <div class="container pt-4">

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "iamproperty"
   },
   "private": false,
-  "version": "5.3.0-beta3",
+  "version": "5.3.0-beta4",
   "scripts": {
     "bootstrap": "copyfiles -u 2 node_modules/bootstrap/**/* assets/bootstrap",
     "dev": "npm run copy && node local_modules/delete-assets.js && vite --host",

--- a/src/components/Nav/Nav.vue
+++ b/src/components/Nav/Nav.vue
@@ -15,7 +15,7 @@ export default {
 
     this.$nextTick(function () {
       
-      import(`../../../assets/js/components/nav/nav.component${import.meta.env.DEV == "development" ? '.min' : ''}.js`).then(module => {
+      import(`../../../assets/js/components/nav/nav.component.min.js`).then(module => {
 
         if (!window.customElements.get(`iam-nav`))
           window.customElements.define(`iam-nav`, module.default);

--- a/test.html
+++ b/test.html
@@ -106,7 +106,7 @@
           rootMargin: '50px',
           threshold: 0.1
         }
-        const componentExt = ".component.js";
+        const componentExt = ".component.min.js";
 
         // Load components - Each component will load once the first of its type has been loaded
         components.forEach((component) => {
@@ -179,23 +179,61 @@
 </head>
 <body>
 
-  <iam-nav>
+  <nav>
+    <iam-nav>
+      <a href="/" class="brand brand--property" slot="logo"><svg><title>iam key</title><use xlink:href="/svg/logo.svg#logo-property"></use></svg></a>
 
-    <a href="/" class="brand brand--movebutler" slot="logo">
-      <svg>
-        <title>iamproperty Movebutler</title>
-        <use xlink:href="/svg/logo.svg#logo-movebutler"></use>
-      </svg>
-    </a>
 
-    <a href="/" class="selected">Lorem ipsum</a>
-    <a href="/">Lorem ipsum</a>
-    <a href="/">Lorem ipsum</a>
-    <a href="/">Lorem ipsum</a>
+      <a href="/">Dashboard</a>
+        <a href="/">View all stock</a>
+          <a href="/">Upload a viewing</a>
 
-    <button class="btn btn-primary">Lorem ipsum</button>
 
-  </iam-nav>
+          <a href="/">Mosa leads</a>
+
+          <a href="/">Order marketing</a>
+
+          <!-- <a href="/">AuctionBoost</a>Needed? -->
+
+      <div class="nav--menu" data-title="My account" data-open-title="Martin Critchlow" data-icon="fa-user fa-solid" slot="menus">
+ 
+        <div>
+                <label for="test1">Active branch</label>
+                <select class="form-select" name="test1" id="test1">
+                    <option value="1">Newcastle</option>
+                    <option value="2">Two</option>
+                    <option value="2">Three</option>
+                    <option value="2">Four</option>
+                </select>
+            </div>
+            <hr class="mt-3">
+            
+        <a href="/">Agency settings</a> <!-- Edit Agent Landing Page -->
+        <a href="/">Your rewards</a>
+        <a href="/">The Success Hub</a>
+
+        <a href="/cp/account-overview">Control panel</a>
+        
+        <a href="/">Notifications</a><!-- Need notification number? -->
+
+        <a href="/">Quick start guide & FAQ</a><!--Footer -->
+        <a href="/">Contact us</a> <!-- What link? -->
+        <a href="/">Log out</a>
+
+          
+      </div>
+
+
+
+      <a href="/" slot="secondary" >iamproperty</a>
+      <a href="https://vtopenview.com/MyDay" slot="secondary">CRM</a>
+      <a href="/" slot="secondary">movebutler</a>
+      <a href="/" slot="secondary" class="selected">iamsold</a>
+
+
+    </iam-nav>
+    </nav>
+
 
 
 


### PR DESCRIPTION
## Summary of Changes
1. Allow for details menu in pull out menu.

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /standalone/agent
- /standalone/movebutler

## Ticket(s)
FEG-331

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
