### PR TITLE
Feg 389/feature/manual addr lookup

### DIFF
--- a/assets/ts/components/address-lookup/address-lookup.component.ts
+++ b/assets/ts/components/address-lookup/address-lookup.component.ts
@@ -141,6 +141,15 @@ class iamAddressLookup extends HTMLElement {
       });
     }
 
+    if(this.hasAttribute('data-manual')){
+      lookupWrapper.classList.add('js-hide');
+      manualWrapper.classList.remove('js-hide');
+
+      Array.from(manualWrapper.querySelectorAll('[data-required]')).forEach((input, index) => {
+        input.setAttribute('required','true');
+      });
+    }
+      
     function openManualWrapper (){
       lookupWrapper.classList.add('js-hide');
       manualWrapper.classList.remove('js-hide');

--- a/docs/views/components/AddressLookupDoc.vue
+++ b/docs/views/components/AddressLookupDoc.vue
@@ -16,9 +16,9 @@
 
     <div class="container visualtest">
 
-      <AddressLookup data-url="/addressess2.json?search=">
+      <AddressLookup data-url="/addressess2.json?search=" data-open>
                         
-        <label>Address line one <input type="text" name="address-line-1" data-name="address_1" required /></label>
+        <label>Address line one <input type="text" name="address-line-1" data-name="address_1" value="142" required /></label>
         
         <label>Address line two (Optional) <input type="text" name="address-line-2" data-name="address_2" /></label>
           
@@ -47,6 +47,7 @@
         </label>
       </AddressLookup>
       
+      <p class="note"><strong>Note:</strong> To have the manual address lookup open on page load include the data attribute [data-manual].</p>
     </div>
 
     <div class="container pb-0">

--- a/docs/views/components/AddressLookupDoc.vue
+++ b/docs/views/components/AddressLookupDoc.vue
@@ -16,7 +16,7 @@
 
     <div class="container visualtest">
 
-      <AddressLookup data-url="/addressess2.json?search=" data-open>
+      <AddressLookup data-url="/addressess2.json?search=">
                         
         <label>Address line one <input type="text" name="address-line-1" data-name="address_1" value="142" required /></label>
         

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "iamproperty"
   },
   "private": false,
-  "version": "5.5.0",
+  "version": "5.5.1-beta-1",
   "scripts": {
     "bootstrap": "copyfiles -u 2 node_modules/bootstrap/**/* assets/bootstrap",
     "dev": "npm run copy && node local_modules/delete-assets.js && vite --host",


### PR DESCRIPTION
## Summary of Changes
1. Allow for the manual address lookup to be open using the data attribute [data-manual]

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /components/addresslookup

## Ticket(s)
FEG-389

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
