### PR TITLE
FEG-411-removing max height from textarea field

### DIFF
--- a/assets/sass/elements/forms.scss
+++ b/assets/sass/elements/forms.scss
@@ -50,6 +50,10 @@ $icon-tick: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' view
   min-height: calc(var(--input-padding-block, #{rem(12)}) + var(--input-padding-block, #{rem(12)}) + var(--input-lh, #{rem(20)}) + 4px);
   max-height: calc(var(--input-padding-block, #{rem(12)}) + var(--input-padding-block, #{rem(12)}) + var(--input-lh, #{rem(20)}) + 4px);
 
+  &:is(textarea) {
+    max-height: 100%
+  }
+
   // Customize the `:focus` state to imitate native WebKit styles.
   &:is(:focus,.focus):not(:disabled) {
     border-color: var(--colour-info);
@@ -80,7 +84,6 @@ $icon-tick: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' view
 
 textarea {
   min-height: calc(var(--input-padding-block, #{rem(12)}) + var(--input-padding-block, #{rem(12)}) + (var(--input-lh, #{rem(20)}) * 3) + 4px)!important;
-  max-height: calc(var(--input-padding-block, #{rem(12)}) + var(--input-padding-block, #{rem(12)}) + (var(--input-lh, #{rem(20)}) * 3) + 4px)!important;
 }
 // #endregion
 


### PR DESCRIPTION
## Summary of Changes
1. removed max height from textarea component
2. overrode max height style for textarea

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /form/inputs

## Ticket(s)
FEG-411

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
