### PR TITLE
Fixing broken links across the documentation

### DIFF
--- a/docs/views/DialogUsage.vue
+++ b/docs/views/DialogUsage.vue
@@ -30,7 +30,7 @@
           <td><strong>Optional</strong>: Banners remain until dismissed by the user, or if the state that caused the banner is resolved</td>
         </tr>
         <tr>
-          <td><a href="/components/modal">Modal</a></td>
+          <td><a href="/dialogs/modal">Modal</a></td>
           <td>High priority</td>
           <td><strong>Required</strong>: Modals block app usage until the user takes a dialog action or exits the dialog (if available)</td>
         </tr>

--- a/docs/views/NotificationsUsage.vue
+++ b/docs/views/NotificationsUsage.vue
@@ -12,27 +12,27 @@
     </thead>
     <tbody>
       <tr>
-        <td><a href="/components/toasts">Toasts</a></td>
+        <td><a href="/notifications/toasts">Toasts</a></td>
         <td>Low priority</td>
         <td><strong>Optional:</strong> Toasts disappear automatically</td>
       </tr>
       <tr>
-        <td><a href="/components/inline-notification">Inline notification</a></td>
+        <td><a href="/notifications/inline-notification">Inline notification</a></td>
         <td>Medium priority</td>
         <td><strong>Optional:</strong> Inline notifications appear amongst the page content in the relevant area and remain until the state that cause the inline notification is resolved. </td>
       </tr>
       <tr>
-        <td><a href="/components/alert">Alert</a></td>
+        <td><a href="/notifications/alert">Alert</a></td>
         <td>Prominent, medium priority</td>
         <td><strong>Optional:</strong> Alerts remain until dismissed by the user, or if the state that caused the alert is resolved</td>
       </tr>
       <tr>
-        <td><a href="/elements/modal#transactional">Transactional modal</a></td>
+        <td><a href="/dialogs/modal#transactional">Transactional modal</a></td>
         <td>High priority</td>
         <td><strong>Required:</strong> Modals block app usage until the user takes a dialog action. There are usually two options - one to complete the action and one to offer the user not to complete the action</td>
       </tr>
       <tr>
-        <td><a href="/elements/modal#acknowledgement">Acknowledgement modal</a></td>
+        <td><a href="/dialogs/modal#acknowledgement">Acknowledgement modal</a></td>
         <td>High priority</td>
         <td><strong>Required:</strong> Modals block app usage until the user takes a dialog action. Users are offered a mandatory action - they acknowledge the system notification and are in line with compliance or legal requirements.</td>
       </tr>

--- a/docs/views/dialogs/DialogDoc.vue
+++ b/docs/views/dialogs/DialogDoc.vue
@@ -114,9 +114,9 @@
     <div class="container pt-5 pb-5">
       <h2>Different dialog types</h2>
       <div class="row row-cols-1 row-cols-md-3">
-        <div><a href="/components/modal"><Card>Dialog (Modal)</Card></a></div>
-        <div><a href="/components/nonmodal"><Card>Dialog (Non-Modal)</Card></a></div>
-        <div><a href="/components/popover"><Card>Dialog (Popover)</Card></a></div>
+        <div><a href="/dialogs/modal"><Card>Dialog (Modal)</Card></a></div>
+        <div><a href="/dialogs/nonmodal"><Card>Dialog (Non-Modal)</Card></a></div>
+        <div><a href="/dialogs/popover"><Card>Dialog (Popover)</Card></a></div>
       </div>
     </div>
 

--- a/docs/views/dialogs/ModalDoc.vue
+++ b/docs/views/dialogs/ModalDoc.vue
@@ -20,7 +20,7 @@
       
       <DialogUsage></DialogUsage>
 
-      <p>For more context of when to use modals and when not to, see the <a href="/components/dialog">dialog</a> page for further details. </p>
+      <p>For more context of when to use modals and when not to, see the <a href="/dialogs/dialog">dialog</a> page for further details. </p>
     </div>
 
 

--- a/docs/views/dialogs/NonModalDoc.vue
+++ b/docs/views/dialogs/NonModalDoc.vue
@@ -97,7 +97,7 @@
     <div class="container pt-5 pb-5">
       <h2>Different Non-Modal dialogs types</h2>
       <div class="row row-cols-1 row-cols-md-3">
-        <div><a href="/components/popover"><Card>Dialog (Popover)</Card></a></div>
+        <div><a href="/dialogs/popover"><Card>Dialog (Popover)</Card></a></div>
       </div>
     </div>
 

--- a/docs/views/elements/Media.vue
+++ b/docs/views/elements/Media.vue
@@ -40,7 +40,7 @@
 
       <h2>YouTube video</h2>
 
-      <p>Videos can be added to the site in two ways; as a component on the page with a preview image (from youTube), or they via a <a href="/components/modal">modal component</a>.</p>
+      <p>Videos can be added to the site in two ways; as a component on the page with a preview image (from youTube), or they via a <a href="/dialogs/modal">modal component</a>.</p>
     </div>
     <div class="container visualtest">
       <div class="row">

--- a/docs/views/form/FormInputDoc.vue
+++ b/docs/views/form/FormInputDoc.vue
@@ -150,14 +150,14 @@
       <div>
         <label :for="`input9`">Input field label</label>
         <span class="prefix fa-solid fa-envelope"></span>
-        <input type="text" :id="`input9`" :name="`input9`" placeholder="Optional placheolder text" required />
+        <input type="text" :id="`input9`" :name="`input9`" placeholder="Optional placeholder text" required />
       </div>
  
       <h4 class="lead text-body text-uppercase pb-2">Focus state</h4>
       <div>
         <label :for="`input10`">Input field label</label>
         <span class="prefix fa-solid fa-envelope"></span>
-        <input type="text" :id="`input10`" :name="`input10`" class="focus" placeholder="Optional placheolder text" required />
+        <input type="text" :id="`input10`" :name="`input10`" class="focus" placeholder="Optional placeholder text" required />
       </div>
 
       <p>When we use an icon as a prefix or suffix it should be solid and 1 rem (16px) in size with 1rem (16px) padding around the icon.</p>
@@ -169,7 +169,7 @@
       <div>
         <label :for="`input11`">Input field label</label>
         <span class="suffix">days</span>
-        <input type="text" :id="`input11`" :name="`input11`" placeholder="Optional placheolder text" required />
+        <input type="text" :id="`input11`" :name="`input11`" placeholder="Optional placeholder text" required />
       </div>
  
       <h4 class="lead text-body text-uppercase pb-2">Default state</h4>
@@ -177,7 +177,7 @@
       <div>
         <label :for="`input12`">Input field label</label>
         <span class="suffix">days</span>
-        <input type="text" :id="`input12`" :name="`input12`" placeholder="Optional placheolder text" required class="focus" />
+        <input type="text" :id="`input12`" :name="`input12`" placeholder="Optional placeholder text" required class="focus" />
       </div>
 
       <p>When we use text we should keep it to a minimum. For example, using for units of measurement. The text should be 1rem (16px) within a container height of 1.5rem (24px) and a max width of 5rem (80px). The padding around the container should be 1rem (16px) left and right and 0.75rem (12px) top and bottom.</p>
@@ -265,7 +265,7 @@
       <div>
         <label :for="`input16`">Input field label</label>
         <span class="suffix">days</span>
-        <input type="text" :id="`input16`" :name="`input16`" placeholder="Optional placheolder text" required />
+        <input type="text" :id="`input16`" :name="`input16`" placeholder="Optional placeholder text" required />
         <span>Optional helper text</span>
       </div>
     </div>
@@ -277,7 +277,7 @@
     <div class="container visualtest">
       <div>
         <label :for="`input17`">Input field label</label>
-        <input type="text" :id="`input17`" :name="`input17`" placeholder="Optional placheolder text" required maxlength="100" />
+        <input type="text" :id="`input17`" :name="`input17`" placeholder="Optional placeholder text" required maxlength="100" />
         <span>Optional helper text</span>
         
       </div>
@@ -468,12 +468,12 @@
           <pre><code class="html">{{`<div>
   <label for="input">Input field label</label>
   <span class="prefix fa-solid fa-envelope"></span>
-  <input type="text" id="input" name="input" placeholder="Optional placheolder text" required="" />
+  <input type="text" id="input" name="input" placeholder="Optional placeholder text" required="" />
 </div>
 
 <label>
   Input field label
-  <div><span class="prefix fa-solid fa-envelope"></span><input type="text" name="input" placeholder="Optional placheolder text" required="" /></div>
+  <div><span class="prefix fa-solid fa-envelope"></span><input type="text" name="input" placeholder="Optional placeholder text" required="" /></div>
 </label>`}}</code></pre>
         </details>
         <details>

--- a/docs/views/notifications/SystemNotificationsDoc.vue
+++ b/docs/views/notifications/SystemNotificationsDoc.vue
@@ -104,11 +104,11 @@
       <h2>Notification types</h2>
       <p>Components available in the iamproperty design system.</p>
       <div class="row row-cols-1 row-cols-md-3">
-        <div><a href="/components/toasts"><Card :data-image="toast" class="card--lg-image">Toasts</Card></a></div>
-        <div><a href="/components/inline-notification"><Card :data-image="inlineNotification" class="card--lg-image">Inline</Card></a></div>
-        <div><a href="/components/alert"><Card :data-image="alert" class="card--lg-image">Alert</Card></a></div>
-        <div><a href="/components/modal#transactional"><Card :data-image="modalTransactional" class="card--lg-image">Transactional modal</Card></a></div>
-        <div><a href="/components/modal#acknowledgement"><Card :data-image="modalAcknowledgement" class="card--lg-image">Acknowledgement modal</Card></a></div>
+        <div><a href="/notifications/toasts"><Card :data-image="toast" class="card--lg-image">Toasts</Card></a></div>
+        <div><a href="/notifications/inline-notification"><Card :data-image="inlineNotification" class="card--lg-image">Inline</Card></a></div>
+        <div><a href="/notifications/alert"><Card :data-image="alert" class="card--lg-image">Alert</Card></a></div>
+        <div><a href="/dialogs/modal#transactional"><Card :data-image="modalTransactional" class="card--lg-image">Transactional modal</Card></a></div>
+        <div><a href="/dialogs/modal#acknowledgement"><Card :data-image="modalAcknowledgement" class="card--lg-image">Acknowledgement modal</Card></a></div>
       </div>
     </div>
 

--- a/docs/views/selectionControls.vue
+++ b/docs/views/selectionControls.vue
@@ -12,7 +12,7 @@
     </thead>
     <tbody>
       <tr>
-        <td><a href="/components/radio">Radio buttons</a></td>
+        <td><a href="/form/radio">Radio buttons</a></td>
         <td>
           <ul class="mb-0">
             <li>Select a single option from a list</li>
@@ -21,7 +21,7 @@
         </td>
       </tr>
       <tr>
-        <td><a href="/components/form/checkbox">Checkboxes</a></td>
+        <td><a href="/form/checkbox">Checkboxes</a></td>
         <td>
           <ul class="mb-0">
             <li>Select one or more options from a list</li>
@@ -30,7 +30,7 @@
         </td>
       </tr>
       <tr>
-        <td><a href="/components/form/toggle">Switches</a></td>
+        <td><a href="/form/toggle">Switches</a></td>
         <td>
           <ul class="mb-0">
             <li>Toggle a single item on or off</li>


### PR DESCRIPTION
## Summary of Changes
1. Updated links across the documentation to go to the intended pages
2. Fixed a couple of typos

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /page

## Ticket(s)
FEG-441

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
