### PR TITLE
adding thumbnail paginated variant of the carousel and a close event …

### DIFF
--- a/assets/sass/components/carousel.scss
+++ b/assets/sass/components/carousel.scss
@@ -130,18 +130,35 @@
 
 // #region carousel controls/pips
 .carousel .carousel__controls {
-
-  text-align: center;
-  width: 10rem;
-  max-height: 1rem;
   overflow: hidden;
   margin-inline: auto;
     
+  &:not(.thumbnails){
+    max-height: 1rem;
+    width: 10rem;
+    text-align: center;
+  }
+
+  &.thumbnails {
+    margin-block-start: 2rem;
+  }
+
   @include media-breakpoint-up(sm) {
     width: 100%;
   }
 
   button {
+    padding: 0;
+    margin: 0 0.2rem 0.2rem;
+    border: 3px solid var(--colour-canvas);
+    border-radius: 4px;
+
+    &.has-thumbnail {
+      max-width: 7rem;
+    }
+  }
+
+  button:not(.has-thumbnail) {
     width: 1rem;
     height: 1rem;
     min-height: 1rem;
@@ -149,10 +166,9 @@
     text-indent: -50rem;
     overflow: hidden;
     background: var(--colour-primary-theme);
-    padding: 0;
     margin: 0 0.5rem 0.5rem 0.5rem;
     border: none;
-
+    
     &:before {
       display: none;
     }
@@ -164,8 +180,12 @@
 }
 
 .carousel__controls > button[aria-current] {
+  --colour-active-thumbnail: var(--colour-info); 
+  border-color: var(--colour-active-thumbnail);
 
-  background: var(--colour-success);
+  &:not(.has-thumbnail) {
+    background: var(--colour-success);
+  }
 }
 
 // #endregion

--- a/assets/sass/components/carousel.scss
+++ b/assets/sass/components/carousel.scss
@@ -154,7 +154,12 @@
     border-radius: 4px;
 
     &.has-thumbnail {
-      max-width: 7rem;
+      height: 4.625rem;
+
+      img {
+        height: 100%;
+        width: auto;
+      }
     }
   }
 

--- a/assets/ts/components/carousel/carousel.component.ts
+++ b/assets/ts/components/carousel/carousel.component.ts
@@ -49,6 +49,8 @@ class iamCarousel extends HTMLElement {
     
     const carouselElement = this.shadowRoot.querySelector('.carousel');
     const row = this.querySelector('.row');
+    const thumbnailImages = JSON.parse(this.dataset.thumbnails);
+
     const carouselControls = this.shadowRoot.querySelector('.carousel__controls');
 
     let itemCount = this.querySelectorAll(':scope > .row > .col').length
@@ -61,10 +63,24 @@ class iamCarousel extends HTMLElement {
     if(this.classList.contains('hide-controls'))
       carouselElement.classList.add('hide-controls');
 
+    if (thumbnailImages?.length) {
+      carouselControls.classList.add('thumbnails');
+    }
+
     // populate the pips
     let pips = "";
     for (let i = 1; i <= itemCount; i++) {
-      pips += `<button class="control-${i}" data-slide="${i}" ${i == 1 ? "aria-current":""}>Slide ${i}</button>`;
+      let pipContent = null;
+      let pipClass = '';
+
+      if(thumbnailImages.length){
+        pipClass = 'has-thumbnail';
+        pipContent = `<img src="${thumbnailImages[i - 1].src}" alt="Slide ${i}" height="74"/>`;
+      } else {
+        pipContent = `Slide ${i}`;
+      }
+
+      pips += `<button class="control-${i} ${pipClass}" data-slide="${i}" ${i == 1 ? "aria-current":""}>${pipContent}</button>`;
     }
     carouselControls.innerHTML = pips;
 

--- a/assets/ts/components/carousel/carousel.component.ts
+++ b/assets/ts/components/carousel/carousel.component.ts
@@ -75,7 +75,7 @@ class iamCarousel extends HTMLElement {
 
       if(thumbnailImages.length){
         pipClass = 'has-thumbnail';
-        pipContent = `<img src="${thumbnailImages[i - 1].src}" alt="Slide ${i}" height="74"/>`;
+        pipContent = `<img src="${thumbnailImages[i - 1].src}" alt="Slide ${i}" height="148"/>`;
       } else {
         pipContent = `Slide ${i}`;
       }

--- a/assets/ts/modules/dialogs.ts
+++ b/assets/ts/modules/dialogs.ts
@@ -72,6 +72,14 @@ const extendDialogs = (body) => {
         btnElement.classList.remove('active');
       });
 
+      let closeEvent = new CustomEvent('dialog-closed', {
+        bubbles: true,
+        cancelable: true,
+        detail: { modalId: dialog.id }
+      });
+
+      event.target.dispatchEvent(closeEvent);
+
       window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         "event": "closeModal",

--- a/audit.json
+++ b/audit.json
@@ -1,10 +1,10 @@
 {
-  "css_size": "173kb",
-  "css_core_size": "135kb",
-  "js_size": "71kb",
+  "css_size": "174kb",
+  "css_core_size": "167kb",
+  "js_size": "77kb",
   "logo_size": "25kb",
-  "img_size": "9kb",
-  "img_count": 2,
+  "img_size": "151kb",
+  "img_count": 3,
   "fonts_size": "56kb",
   "fonts_count": 3
 }

--- a/docs/views/components/CarouselDoc.vue
+++ b/docs/views/components/CarouselDoc.vue
@@ -22,6 +22,19 @@
     </div>
 
     <div class="container">
+      <h3>Carousel with Image Thumbnails</h3>
+      <p>To implement this, you will need to pass an array of thumbnail objects.</p>
+
+      <Carousel :thumbnails="thumbnails">
+      
+        <div :class="`row row-cols-1`">
+          <div :class="`col carousel__item`" v-for="(value,index) in thumbnailCarouselItems" :key="`${carouselId}${index}`" v-html="content(value)" :id="`carousel-slide${index+1}`"></div>
+        </div>
+      
+      </Carousel>
+    </div>
+
+    <div class="container">
       <h3>Carousel examples</h3>
       <p>This component can be configured in various ways with different types of cards alongside changing background of the container.</p>
       <a href="/examples#carousels" class="btn btn-secondary">See carousels examples</a>
@@ -121,7 +134,48 @@ export default {
         {
           content: `<span class="h2">Item 12</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
         }
-      ]
+      ],
+      thumbnailCarouselItems: [
+            {
+                content: `<span class="h4">Carousel Item 1</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+            },
+            {
+                content: '<img src="https://place-hold.it/500x300"/>'
+            },
+            {
+                content: '<img src="https://place-hold.it/500x300"/>'
+            },
+            {
+                content: '<img src="https://place-hold.it/500x300"/>'
+            },
+            {
+                content: '<img src="https://place-hold.it/500x300"/>'
+            },
+            {
+                content: '<img src="https://place-hold.it/500x300"/>'
+            },
+    
+        ],
+        thumbnails: [
+            {
+                src: 'https://place-hold.it/111x74'
+            },
+            {
+                src: 'https://place-hold.it/111x74'
+            },
+            {
+                src: 'https://place-hold.it/111x74'
+            },
+            {
+                src: 'https://place-hold.it/111x74'
+            }, 
+            {
+                src: 'https://place-hold.it/111x74'
+            },
+            {
+                src: 'https://place-hold.it/111x74'
+            },
+        ]
     }
   }
 }

--- a/docs/views/components/CarouselDoc.vue
+++ b/docs/views/components/CarouselDoc.vue
@@ -164,10 +164,10 @@ export default {
                 src: 'https://place-hold.it/111x74'
             },
             {
-                src: 'https://place-hold.it/111x74'
+                src: 'https://place-hold.it/50x74'
             },
             {
-                src: 'https://place-hold.it/111x74'
+                src: 'https://place-hold.it/60x74'
             }, 
             {
                 src: 'https://place-hold.it/111x74'

--- a/docs/views/dialogs/DialogDoc.vue
+++ b/docs/views/dialogs/DialogDoc.vue
@@ -109,6 +109,11 @@
       
     </div>
 
+    <div class="container">
+      <h3>Custom Events</h3>
+      <p>On closing a modal, the 'dialog-closed' cutom event will be dispatched. It will send an object with the modal ID in it as the detail.</p>
+    </div>
+
     <NonModelDesc></NonModelDesc>
 
     <div class="container pt-5 pb-5">

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "iamproperty"
   },
   "private": false,
-  "version": "5.6.1-beta17",
+  "version": "5.6.1-beta18",
   "scripts": {
     "bootstrap": "copyfiles -u 2 node_modules/bootstrap/**/* assets/bootstrap",
     "dev": "npm run copy && node local_modules/delete-assets.js && vite --host",

--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- Custom element -->
-  <iam-carousel>
+  <iam-carousel :data-thumbnails="JSON.stringify(thumbnails)">
     
     <slot></slot>
   </iam-carousel>
@@ -19,6 +19,10 @@ export default {
     image: {
       type: String,
       required: false
+    },
+    thumbnails: {
+      type: Array, 
+      default: () => []
     }
   },
   mounted(){


### PR DESCRIPTION
…for modals

## Summary of Changes
1. added custom event to modal component to be dispatched when closed
2. added the option to pass thumbnails through to a carousel, to be used instead of pagination dots
3. Updated documentation pages

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /components/carousel

## Ticket(s)
FEG-452

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
