### PR TITLE
changing from += to = to prevent multiple instances of data-filename …

### DIFF
--- a/assets/ts/modules/fileupload.ts
+++ b/assets/ts/modules/fileupload.ts
@@ -166,7 +166,7 @@ function fileupload(fileupload: Element, wrapper: Element) {
     let filename = fileupload.getAttribute('data-filename');
 
     if(filename)
-      filesWrapper.innerHTML += `<span class="file">${filename} <button data-file="${filename}">Remove</button></span>`;
+      filesWrapper.innerHTML = `<span class="file">${filename} <button data-file="${filename}">Remove</button></span>`;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "iamproperty"
   },
   "private": false,
-  "version": "5.6.1-beta18",
+  "version": "5.6.1-beta19",
   "scripts": {
     "bootstrap": "copyfiles -u 2 node_modules/bootstrap/**/* assets/bootstrap",
     "dev": "npm run copy && node local_modules/delete-assets.js && vite --host",


### PR DESCRIPTION
…appearing

## Summary of Changes
1. updated the function on component load where the value of data-filename is added as a file tag, to replace any existing content instead of adding to it


## Review
- Run the site from the develop branch and in docs\views\components\File.vue, add an attribute of data-filename, with a value matching a file you can use to test (image (5).png in my case)
- navigate to the components/file page
- a duplicate filename will show 
![image](https://github.com/user-attachments/assets/24a63212-7125-4b2a-bed9-36ec716a94a2)

- Pull down the branch and in docs\views\components\File.vue, add an attribute of data-filename, with a value matching a file you can use to test (image (5).png in my case)
- run the site and navigate to components/file
- Only one filename should show the previously uploaded image

## Ticket(s)
FEG-454

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
