### PR TITLE
Feg 455/bug/issues with carousel pagination not matching up to current slide

### DIFF
--- a/assets/sass/components/carousel.scss
+++ b/assets/sass/components/carousel.scss
@@ -135,6 +135,7 @@
     
   &:not(.thumbnails){
     text-align: center;
+    max-width: 30rem;
   }
 
   &.thumbnails {

--- a/assets/sass/components/carousel.scss
+++ b/assets/sass/components/carousel.scss
@@ -134,8 +134,6 @@
   margin-inline: auto;
     
   &:not(.thumbnails){
-    max-height: 1rem;
-    width: 10rem;
     text-align: center;
   }
 

--- a/assets/ts/modules/carousel.ts
+++ b/assets/ts/modules/carousel.ts
@@ -24,7 +24,7 @@ function carousel(carouselElement, row) {
       let visibleItems = Math.round(scrollArea / itemWidth);
 
       //Check if theres room for more slides than we have
-      let leftOverSpace = (Math.round(itemCount / visibleItems) * visibleItems) - itemCount;
+      let leftOverSpace = (Math.ceil(itemCount / visibleItems) * visibleItems) - itemCount;
 
       if(leftOverSpace > 0 && lastItemInView){
         targetSlide = (Math.floor(itemCount / visibleItems) * visibleItems) + 1;
@@ -80,11 +80,25 @@ function carousel(carouselElement, row) {
   
   carouselElement.addEventListener('click', function(e){
 
+    let scrollArea = carouselInner.clientWidth;
+    let scrollWidth = carouselInner.scrollWidth;
+    let itemWidth = row.querySelector(':scope > .col').scrollWidth;
+
+    let visibleItems = Math.round(scrollArea / itemWidth);
+
+    let lastItemOffset = row.querySelector(':scope > .col:last-child').offsetLeft;
+    let lastItemInView = carouselInner.scrollLeft + scrollArea >= (lastItemOffset + 100);
+
+    //Check if theres room for more slides than we have
+    let leftOverSpace = (Math.ceil(itemCount / visibleItems) * visibleItems) - itemCount;
+
+    let movement = lastItemInView && leftOverSpace > 0 ? leftOverSpace * itemWidth : carouselInner.clientWidth;
+
     for (var target = e.target; target && target != this; target = target.parentNode) {
       if (typeof target.matches == "function" && target.matches('.btn-next, .btn-prev')) {
         
         e.preventDefault();
-        let scrollTo = target.classList.contains('btn-prev') ? carouselInner.scrollLeft - carouselInner.clientWidth : carouselInner.scrollLeft + carouselInner.clientWidth;
+        let scrollTo = target.classList.contains('btn-prev') ? carouselInner.scrollLeft - movement : carouselInner.scrollLeft + carouselInner.clientWidth;
         
         carouselInner.scroll({
           top: 0,

--- a/assets/ts/modules/carousel.ts
+++ b/assets/ts/modules/carousel.ts
@@ -16,14 +16,19 @@ function carousel(carouselElement, row) {
       let scrollWidth = carouselInner.scrollWidth;
       let scrollLeft = carouselInner.scrollLeft;
       let targetSlide = Math.round((scrollLeft / scrollWidth) * itemCount) + 1;
-      let lastItemOffset = row.querySelector(':scope > .col:last-child').offsetLeft - 50;
+     
       let itemWidth = row.querySelector(':scope > .col').scrollWidth;
+      let lastItemOffset = row.querySelector(':scope > .col:last-child').offsetLeft;
+      let lastItemInView = carouselInner.scrollLeft + scrollArea >= (lastItemOffset + 100);
+
       let visibleItems = Math.round(scrollArea / itemWidth);
 
-      if(carouselInner.scrollLeft + scrollArea >= lastItemOffset){
+      //Check if theres room for more slides than we have
+      let leftOverSpace = (Math.round(itemCount / visibleItems) * visibleItems) - itemCount;
 
+      if(leftOverSpace > 0 && lastItemInView){
         targetSlide = (Math.floor(itemCount / visibleItems) * visibleItems) + 1;
-      }
+      } 
       
       Array.from(carouselElement.querySelectorAll('.carousel__controls button')).forEach((button, index) => {
         button.removeAttribute('aria-current');
@@ -38,7 +43,7 @@ function carousel(carouselElement, row) {
         carouselElement.querySelector('.btn-prev').removeAttribute('disabled');
 
       // Disable the next button if the last item is in view
-      if(targetSlide == itemCount)
+      if(targetSlide > (itemCount - visibleItems))
         carouselElement.querySelector('.btn-next').setAttribute('disabled','disabled');
       else
         carouselElement.querySelector('.btn-next').removeAttribute('disabled');

--- a/docs/views/components/CarouselDoc.vue
+++ b/docs/views/components/CarouselDoc.vue
@@ -44,6 +44,7 @@
       <h2>Vue Card component reference</h2>
       <Readme></Readme>
     </div>
+    
   </main>
 </template>
 
@@ -133,7 +134,40 @@ export default {
         },
         {
           content: `<span class="h2">Item 12</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
-        }
+        },{
+          content: `<span class="h2">Item 13</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 14</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 15</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 16</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 17</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 18</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 19</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 20</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 21</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 22</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+        {
+          content: `<span class="h2">Item 23</span><p>It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages..</p>`
+        },
+ 
       ],
       thumbnailCarouselItems: [
             {


### PR DESCRIPTION
## Summary of Changes
1. updated carousel JS to account for an item count that isn't divisible by the number of items per 'slide'
2. increased width and removed height from pagination controls so that more pips can show

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /components/carousel
- Navigate to the end of the first carousel on the page (item 23 should show)
- the last pagination dot should be highlighted
- clicking the previous button should move 2 items back instead of a full 3, because we don't have an item count divisble by 3. 

## Ticket(s)
FEG-455

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
