### PR TITLE
Feg 456/bug/remove need for card to be wrapped in a link button or label

### DIFF
--- a/assets/ts/components/card/card.component.ts
+++ b/assets/ts/components/card/card.component.ts
@@ -58,14 +58,21 @@ class iamCard extends HTMLElement {
   }
 
 	connectedCallback() {
-
     this.classList.add('loaded');
-    
+
     // Mimic clicking the parent node so the focus and target events can be on the card
     const parentNode = this.parentNode.closest('a, button, label, router-link')
     const card = this.shadowRoot.querySelector('.card')
     const btnCompact =  this.shadowRoot.querySelector('.btn-compact');
     const recordType = this.hasAttribute('data-record') ? this.getAttribute('data-record') : '';
+
+    /* 
+      If the parentNode is actually just a div, 
+      we don't want to look for anything or add events 
+    */
+    if (!parentNode) {
+      return false;
+    }
 
     if(parentNode)
       parentNode.setAttribute('tabindex','-1');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "iamproperty"
   },
   "private": false,
-  "version": "5.6.1-beta19",
+  "version": "5.6.1-beta20",
   "scripts": {
     "bootstrap": "copyfiles -u 2 node_modules/bootstrap/**/* assets/bootstrap",
     "dev": "npm run copy && node local_modules/delete-assets.js && vite --host",


### PR DESCRIPTION
## Summary of Changes
1. added check for parentNode being of a certain time to avoid JS errors when the parentNode is a div rather than something clickable. 


## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /page

## Ticket(s)
FEG-456

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
