### PR TITLE
Feg 457/bug/carousel pagination when there are 4 items in view not matching up with controls

### DIFF
--- a/assets/sass/components/address-lookup.scss
+++ b/assets/sass/components/address-lookup.scss
@@ -7,6 +7,10 @@ input[name="postcode"] {
   border-color: var(--error-border,var(--colour-primary))!important;
 }
 
+:is([name="postcode"]):is(:focus,.focus):not(:disabled) {
+  border-color: var(--colour-info)!important;
+}
+
 div:has(input[name="postcode"]) .suffix {
 
   border-color: var(--error-border,var(--colour-primary))!important;

--- a/assets/ts/modules/carousel.ts
+++ b/assets/ts/modules/carousel.ts
@@ -19,7 +19,8 @@ function carousel(carouselElement, row) {
      
       let itemWidth = row.querySelector(':scope > .col').scrollWidth;
       let lastItemOffset = row.querySelector(':scope > .col:last-child').offsetLeft;
-      let lastItemInView = carouselInner.scrollLeft + scrollArea >= (lastItemOffset + 100);
+      //+60px here is to account for when the next offscreen slide is visible beneath the next arrow
+      let lastItemInView = carouselInner.scrollLeft + scrollArea + carouselInner.getBoundingClientRect().left >= (lastItemOffset + 60);
 
       let visibleItems = Math.round(scrollArea / itemWidth);
 
@@ -69,7 +70,7 @@ function carousel(carouselElement, row) {
 
         carouselInner.scroll({
           top: 0,
-          left: el.offsetLeft - 100, 
+          left: el.offsetLeft - carouselInner.getBoundingClientRect().left, 
           behavior: 'smooth'
         });
 
@@ -87,12 +88,19 @@ function carousel(carouselElement, row) {
     let visibleItems = Math.round(scrollArea / itemWidth);
 
     let lastItemOffset = row.querySelector(':scope > .col:last-child').offsetLeft;
-    let lastItemInView = carouselInner.scrollLeft + scrollArea >= (lastItemOffset + 100);
+    let lastItemInView = carouselInner.scrollLeft + scrollArea + carouselInner.getBoundingClientRect().left >= (lastItemOffset + 60);
 
     //Check if theres room for more slides than we have
     let leftOverSpace = (Math.ceil(itemCount / visibleItems) * visibleItems) - itemCount;
 
-    let movement = lastItemInView && leftOverSpace > 0 ? leftOverSpace * itemWidth : carouselInner.clientWidth;
+    /* 
+      When the last slide isn't filled with items, we only want to move back the number of items on the slide, 
+      rather than the total number of possible visible items
+    */
+    let spacesToMove = visibleItems - leftOverSpace;
+
+    //Only want to change the amount of movement if the last item is visible
+    let movement = lastItemInView && leftOverSpace > 0 ? spacesToMove * itemWidth : carouselInner.clientWidth;
 
     for (var target = e.target; target && target != this; target = target.parentNode) {
       if (typeof target.matches == "function" && target.matches('.btn-next, .btn-prev')) {


### PR DESCRIPTION
## Summary of Changes
1. updated navigation on carousel to take into total item counts that aren't divisible by visibleItems
2. updated postcode lookup styles so that focus style is applied.
3. c

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /components/carousel
- Trying different breakpoints, navigate through the carousel using the next and previous arrows, making sure you can access all the slides and the pagination accurately reflects where you are
- Trying different breakpoints, navigate through the carousel using the pagination dots, making sure you can access all the slides and the pagination accurately reflects where you are

## Ticket(s)
FEG-457

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
