### PR TITLE
Updating admin panel css to allow for buttons in header

### DIFF
--- a/assets/sass/elements/admin-panel.scss
+++ b/assets/sass/elements/admin-panel.scss
@@ -29,7 +29,7 @@
   }
 
 
-  > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6, .heading):first-child {
+  > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6, .admin-panel__heading):first-child {
     
     --gradient-direction: -90deg!important;
     background-color:var(--colour-success);
@@ -46,23 +46,32 @@
   }
 
   > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6):first-child,
-  .heading > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6) {
+  .admin-panel__heading > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6) {
     font-size: rem(18);
     line-height: rem(24);
     font-weight: bold;
     padding: rem(16) var(--padding-x);
   }
 
-  .heading {
+  > :is(.admin-panel__heading):first-child {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
     padding: rem(16) var(--padding-x);
 
     > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6) {
       padding: 0;
+      margin-inline-end: auto;
     }
 
     .btn {
-      --btn-margin: 1rem;
-      margin-bottom: 0;
+      --btn-margin: 0;
+    }
+
+    .dialog__wrapper + .btn {
+      --btn-margin: 0.25rem;
+      margin-inline-end: 0;
     }
 
     @media (prefers-color-scheme: light) {

--- a/assets/sass/elements/admin-panel.scss
+++ b/assets/sass/elements/admin-panel.scss
@@ -28,7 +28,8 @@
     display: none;
   }
 
-  > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6):first-child {
+
+  > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6, .heading):first-child {
     
     --gradient-direction: -90deg!important;
     background-color:var(--colour-success);
@@ -37,15 +38,43 @@
       color: var(--colour-primary-theme);
       background-image: linear-gradient(var(--gradient-direction),  var(--colour-info) 0, transparent 100%);
     }
-    
-    font-size: rem(18);
-    line-height: rem(24);
-    font-weight: bold;
-    padding: rem(16) var(--padding-x);
+  
     margin: calc(var(--padding-top) * -1) calc(var(--padding-x) * -1) var(--padding-top) calc(var(--padding-x) * -1);
     display: block;
     border-top-left-radius: rem(8);
     border-top-right-radius: rem(8);
+  }
+
+  > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6):first-child,
+  .heading > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6) {
+    font-size: rem(18);
+    line-height: rem(24);
+    font-weight: bold;
+    padding: rem(16) var(--padding-x);
+  }
+
+  .heading {
+    padding: rem(16) var(--padding-x);
+
+    > :is(h1,h2,h3,h4,h5,h6,.h1,.h2,.h3,.h4,.h5,.h6) {
+      padding: 0;
+    }
+
+    .btn {
+      --btn-margin: 1rem;
+      margin-bottom: 0;
+    }
+
+    @media (prefers-color-scheme: light) {
+      .btn-action,
+      .dialog__wrapper {
+        --colour-canvas-2: #FFFFFF;
+        --colour-heading: var(--colour-primary);
+        --colour-btn-action-hover-bg: var(--colour-light);
+        --colour-btn-hover: var(--colour-primary);
+        --colour-border: #D8D8D8;
+      }
+    }
   }
 
   :is(iam-table, .iam-table) {

--- a/docs/views/elements/PanelDoc.vue
+++ b/docs/views/elements/PanelDoc.vue
@@ -219,6 +219,24 @@
         </Tab>
       </Tabs>
     </div>
+
+    <div class="container">
+      <h2>Admin panel with actions in the header</h2>
+      <p>
+        Instead of a heading element (h2 etc.) as the first child of admin-panel, you can add 
+        a div with a class of 'heading'. The header element inside this div will still be styled as usual. 
+        But you can also add additional content, such as action buttons in the heading div.
+      </p>
+      
+      <div class="admin-panel">
+        <div class="heading bg-primary gradient-info" style="display: grid; grid-template-columns: 1fr auto auto;align-items: center;">
+          <h2>Admin panel title</h2>
+          <div class="dialog__wrapper"><button class="btn btn-action">Quick filter</button><dialog class="dialog--list" data-v-7d119115=""><div class="mb-0" data-v-7d119115=""><input type="radio" name="sort" data-sort="" id="follow-up-oldest" value="follow-up-oldest" data-v-7d119115=""><label for="follow-up-oldest" class="radio--tick" data-v-7d119115="">Follow up date (Oldest to newest)</label><hr data-v-7d119115=""><input type="radio" name="sort" data-sort="" id="follow-up-newest" value="follow-up-newest" data-v-7d119115=""><label for="follow-up-newest" class="radio--tick" data-v-7d119115="">Follow up date (Newest to oldest)</label><hr data-v-7d119115=""><input type="radio" name="sort" data-sort="" id="date-instructed-oldest" value="date-instructed-oldest" checked="" autofocus="true" data-v-7d119115=""><label for="date-instructed-oldest" class="radio--tick" data-v-7d119115="">Date Instructed (Oldest to newest)</label><hr data-v-7d119115=""><input type="radio" name="sort" data-sort="" id="date-instructed-newest" value="date-instructed-newest" data-v-7d119115=""><label for="date-instructed-newest" class="radio--tick mb-0" data-v-7d119115="">Date Instructed (Newest to oldest)</label></div></dialog></div>
+          <button class="btn btn-action">Action</button>
+        </div>
+        <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit</p>
+      </div>
+    </div>
     
 
     <div class="container">

--- a/docs/views/elements/PanelDoc.vue
+++ b/docs/views/elements/PanelDoc.vue
@@ -224,12 +224,12 @@
       <h2>Admin panel with actions in the header</h2>
       <p>
         Instead of a heading element (h2 etc.) as the first child of admin-panel, you can add 
-        a div with a class of 'heading'. The header element inside this div will still be styled as usual. 
+        a div with a class of 'admin-panel__heading'. The header element inside this div will still be styled as usual. 
         But you can also add additional content, such as action buttons in the heading div.
       </p>
       
       <div class="admin-panel">
-        <div class="heading bg-primary gradient-info" style="display: grid; grid-template-columns: 1fr auto auto;align-items: center;">
+        <div class="admin-panel__heading bg-primary gradient-info">
           <h2>Admin panel title</h2>
           <div class="dialog__wrapper"><button class="btn btn-action">Quick filter</button><dialog class="dialog--list" data-v-7d119115=""><div class="mb-0" data-v-7d119115=""><input type="radio" name="sort" data-sort="" id="follow-up-oldest" value="follow-up-oldest" data-v-7d119115=""><label for="follow-up-oldest" class="radio--tick" data-v-7d119115="">Follow up date (Oldest to newest)</label><hr data-v-7d119115=""><input type="radio" name="sort" data-sort="" id="follow-up-newest" value="follow-up-newest" data-v-7d119115=""><label for="follow-up-newest" class="radio--tick" data-v-7d119115="">Follow up date (Newest to oldest)</label><hr data-v-7d119115=""><input type="radio" name="sort" data-sort="" id="date-instructed-oldest" value="date-instructed-oldest" checked="" autofocus="true" data-v-7d119115=""><label for="date-instructed-oldest" class="radio--tick" data-v-7d119115="">Date Instructed (Oldest to newest)</label><hr data-v-7d119115=""><input type="radio" name="sort" data-sort="" id="date-instructed-newest" value="date-instructed-newest" data-v-7d119115=""><label for="date-instructed-newest" class="radio--tick mb-0" data-v-7d119115="">Date Instructed (Newest to oldest)</label></div></dialog></div>
           <button class="btn btn-action">Action</button>


### PR DESCRIPTION

## Summary of Changes
1.  CSS updates to allow for div as first child of admin panel
2.  Added example to admin panel doc page


## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /elements/panel

## Ticket(s)
FEG-459

## Checklist

The below needs to be done before a pull request can be approved:

- [x] The pull request command has been ran `npm run pull-request`
- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
