### PR TITLE
FEG-493 - CRM-600 - Add to backdrop click event listener

### DIFF
--- a/assets/ts/components/nav/nav.component.ts
+++ b/assets/ts/components/nav/nav.component.ts
@@ -236,6 +236,7 @@ class iamNav extends HTMLElement {
       });
 
       backdrop.classList.remove('show');
+      iamNav.classList.remove('open');
     });
 
     // On desktop close other menu's (details) when one is clicked


### PR DESCRIPTION
## Summary of Changes
1. Ensure main `iamNav` element has `open` class removed when clicking backdrop element
2. Backdrop element click event listnere already exists, so just added a line to remove `open` class

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /standalone/navbar-menu

`iam-nav` should still remove `open` class.

## Ticket(s)
FEG-493 (CRM-600)

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
