### PR TITLE
allow for external CSS to be added to components so we can still have…

### DIFF
--- a/assets/sass/_components.scss
+++ b/assets/sass/_components.scss
@@ -5,6 +5,16 @@
 @use 'components/carousel.preload';
 @use 'components/multiselect.preload';
 @use 'components/inline-edit.preload';
+@use "components/charts.config.scss";
+
+ // Make sure the first 
+ main {
+  position: relative;
+  
+  > *:first-child {
+    padding-top: 2rem;
+  }
+}
 
 // #region Undefined web components
 main > :is(*):not(:defined):not(iam-carousel) {

--- a/assets/sass/_corefiles.scss
+++ b/assets/sass/_corefiles.scss
@@ -4,8 +4,12 @@
 @layer reset, elements, components, templates, utilities, overrides;
 
 
+$root: ":root"!default;
+$layers: "true"!default;
+
 // Foundations
 @include layer('reset') {
+  
   @import "foundations/root.scss";
   @import "foundations/reboot.scss";
 }
@@ -16,19 +20,9 @@
 
 @include layer('components') {
 
-  // Make sure the first 
-  main {
-    position: relative;
-    
-    > *:first-child {
-      padding-top: 2rem;
-    }
-  }
-
   // Deal with preloaded state of native components
   @import "_components.scss";
 
-  @import "components/charts.config.scss";
 }
 
 @include layer('templates') {

--- a/assets/sass/components.reset.scss
+++ b/assets/sass/components.reset.scss
@@ -1,46 +1,8 @@
-$darkModeLocal: 'false'!default;
+@charset "UTF-8";
 
-@use "_func.scss" as * with (
-  $darkMode: $darkModeLocal
+@use "_fonts";
+@use "_corefiles.scss" with (
+  $root: ":host", // copied directory from iamkey repo
+  $layers: "false"
 );
 
-@use "foundations/root.scss" with (
-  $root: ":is(iam-card,iam-nav,iam-table,.iamkey)" // copied directory from iamkey repo
-);
-
-a:has(iam-card) {
-  all: unset;
-}
-
-
-:is(iam-card,iam-nav, iam-table, .iamkey) {
-
-  @import "foundations/reboot.scss";
-  
-  @include var(font-family,--font-body);
-  @include var(color,--colour-body);
-  width: 100%;
-  line-height: 1.2;
-  min-height: 100%;
-
-  @import "_elements.scss";
-}
-
-:is(iam-table) {
-  width: auto;
-  max-width: rem(1112);
-  display: block;
-}
-
-
-:is(iam-card,iam-nav, iam-table, .iamkey) {
-  @import "_utilities.scss";
-}
-
-body.js-enabled .js-hide {
-  display: none!important;
-}
-
-body:not(.js-enabled) .js-show {
-  display: none!important;
-}

--- a/assets/sass/foundations/root.scss
+++ b/assets/sass/foundations/root.scss
@@ -2,7 +2,6 @@
 
 //@import "../../bootstrap/scss/_root.scss";
 
-$root: ':root'!default;
 
 #{$root} {
   // Print out the $vars array setup in the variables file so they can be used as CSS vars

--- a/assets/ts/components/barchart/barchart.component.ts
+++ b/assets/ts/components/barchart/barchart.component.ts
@@ -16,6 +16,8 @@ class iamBarChart extends HTMLElement {
     const template = document.createElement('template');
     template.innerHTML = `
     <style>
+    ${this.hasAttribute('css') ? `@import "${this.getAttribute('css')}";` : ``}
+    
     ${loadCSS}
     </style>
     <div class="chart__outer" part="outer">

--- a/assets/ts/components/card/card.component.ts
+++ b/assets/ts/components/card/card.component.ts
@@ -16,6 +16,8 @@ class iamCard extends HTMLElement {
     const template = document.createElement('template');
     template.innerHTML = `
     <style>
+    ${this.hasAttribute('css') ? `@import "${this.getAttribute('css')}";` : ``}
+    
     ${loadCSS}
     </style>
     ${cardHTML}

--- a/assets/ts/components/filter-card/filter-card.component.ts
+++ b/assets/ts/components/filter-card/filter-card.component.ts
@@ -16,6 +16,8 @@ class iamFilerCard extends HTMLElement {
     const template = document.createElement('template');
     template.innerHTML = `
     <style>
+    ${this.hasAttribute('css') ? `@import "${this.getAttribute('css')}";` : ``}
+    
     ${loadCSS}
     </style>
     ${cardHTML}

--- a/assets/ts/components/record-card/record-card.component.ts
+++ b/assets/ts/components/record-card/record-card.component.ts
@@ -16,6 +16,8 @@ class iamRecordCard extends HTMLElement {
     const template = document.createElement('template');
     template.innerHTML = `
     <style>
+    ${this.hasAttribute('css') ? `@import "${this.getAttribute('css')}";` : ``}
+    
     ${loadCSS}
     </style>
     ${cardHTML}

--- a/assets/ts/components/video-card/video-card.component.ts
+++ b/assets/ts/components/video-card/video-card.component.ts
@@ -16,6 +16,8 @@ class iamVideoCard extends HTMLElement {
     const template = document.createElement('template');
     template.innerHTML = `
     <style>
+    ${this.hasAttribute('css') ? `@import "${this.getAttribute('css')}";` : ``}
+    
     ${loadCSS}
     </style>
     ${cardHTML}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "compile:ts": "node node_modules/typescript/bin/tsc --project tscompileconfig.json && fix-esm-import-path assets/js",
     "compile": "npm run compile:sass && npm run compile:ts && npm run compile:js",
     "watch:ts": "tsc-watch -p tscompileconfig.json --onCompilationComplete \"fix-esm-import-path assets/js\"",
-    "watch:sass": "sass --watch assets/sass/main.scss:assets/css/style.min.css assets/sass/core.scss:assets/css/core.min.css assets/sass/components:assets/css/components --style=compressed",
+    "watch:sass": "sass --watch assets/sass/main.scss:assets/css/style.min.css assets/sass/core.scss:assets/css/core.min.css assets/sass/components.reset.scss:assets/css/components.reset.min.css assets/sass/components:assets/css/components --style=compressed",
     "watch": "concurrently \"npm run dev\" \"npm run watch:ts\" \"npm run watch:sass\" \"node local_modules/components.js\"",
     "watch2": "npm run watch:ts && npm run watch:sass && node local_modules/components.js && npm run dev",
     "copy:svg": "copyfiles -u 2 assets/svg/**/* public/svg && copyfiles -u 2 assets/svg/icons.svg public/svg && copyfiles -u 2 assets/svg/logo.svg public/svg",

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+  <title>Under maintenance</title>
+  <!--<link href="../../assets/css/core.min.css" rel="stylesheet">-->
+  <style type="text/css">
+    /* The above CSS should be added into here */
+    .container {
+      display: block;
+      width: calc(100% - 2rem);
+      max-width: 80rem;
+      margin: auto;
+    }
+  </style>    
+</head>
+<body class="">
+
+  <div>
+  <main>
+
+    <div class="container">
+        
+      <iam-barChart class="chart--horizontal chart--display-data" css="../../assets/css/components.reset.min.css">
+        <table>
+        <thead>
+          <tr>
+            <th>Items</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-colour-1="warning">
+            <td>Item 1</td>
+            <td>300</td>
+          </tr>
+          <tr data-colour-1="success">
+            <td>Item 2</td>
+            <td>150</td>
+          </tr>
+          <tr data-colour-1="danger">
+            <td>Item 3</td>
+            <td>100</td>
+          </tr>
+        </tbody>
+        </table>
+      </iam-barChart>
+      
+    </div>
+  </main>
+  </div>
+  
+  <script src="../../assets/js/scripts.bundle.js" type="module"></script>
+  <script src="../../assets/js/components.bundle.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
… standalone components in apps

## Summary of Changes
1. Create a reset CSS file for components that wont have the global CSS set
2. Allow for components to import a separate CSS file 
3. minor sass fixes to allow for variables to be overwritten

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
N/A

## Ticket(s)
FEG-512

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
