### PR TITLE
Fix the colour input type

### DIFF
--- a/assets/sass/elements/forms.scss
+++ b/assets/sass/elements/forms.scss
@@ -143,36 +143,50 @@ div:has(> label:first-child):has(> input) {
     margin-top: rem(8);
   }
 
-  input[type="color"]{
-    width: 3rem!important;
-    flex-shrink: 0!important;
-    flex-grow: 0!important;
-    border-start-end-radius: 0;
-    border-end-end-radius: 0;
-    padding: 0;
-    overflow: hidden;
+}
 
-  
-    &::-moz-color-swatch {
-      
-      border-radius: 0;
-      border: none;
-    }
+// #region colors
 
-    &::-webkit-color-swatch {
-      
-      border-radius: 0;
-      border: none;
-    }
+input[type="color"]{
+  width: 3rem!important;
+  flex-shrink: 0!important;
+  flex-grow: 0!important;
+  border-start-end-radius: 0!important;
+  border-end-end-radius: 0!important;
+  padding: 0!important;
+  overflow: hidden;
+  cursor: pointer!important;
+
+
+  &::-moz-color-swatch {
+    
+    border-radius: 0;
+    border: none;
   }
 
-  output {
-    border-left: none!important;
-    border-end-start-radius: 0!important;
-    border-start-start-radius: 0!important;
-    margin: 0!important;
+  &::-webkit-color-swatch {
+    
+    border-radius: 0;
+    border: none;
   }
 }
+
+label :is(div,span,fieldset):has(input[type="color"] + output){
+  display: flex;
+}
+
+input[type="color"] + output {
+  border-left: none!important;
+  border-end-start-radius: 0!important;
+  border-start-start-radius: 0!important;
+  margin: 0!important;
+}
+
+output {
+  margin-top: 0.5rem !important;
+  margin-bottom: 0 !important;
+}
+// #endregion
 
 div:has(> :is(.form-control-sm, .input--sm)) {
   

--- a/docs/views/form/FormInputDoc.vue
+++ b/docs/views/form/FormInputDoc.vue
@@ -442,11 +442,13 @@
       <p class="pb-3">Colour fields allow the user to either enter the hex colour code in the field or select a colour from the colour picker. The colour picker should default to hex code input.</p>
     </div>
     <div class="container visualtest"> 
-      <div>
-        <label for="color">Input field label</label>
-        <input type="color" id="color" name="color" required="" autocomplete="on" />
-        <output></output>
-      </div>
+      
+      <label for="color">Input field label
+        <div>
+          <input type="color" id="color" name="color" required="" autocomplete="on" />
+          <output></output>
+        </div>
+      </label>
 
     </div>
 


### PR DESCRIPTION
## Summary of Changes
1. Force the CSS of the color inputs using importants
2. Update the docs to test if it works when in a span

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /page

## Ticket(s)
FEG-999

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
