### PR TITLE
Add the choice to have menus in the bar charts

### DIFF
--- a/assets/sass/components/barchart.component.scss
+++ b/assets/sass/components/barchart.component.scss
@@ -1,5 +1,6 @@
 @use '../_func.scss' as *;
 @use 'charts.module.scss' as *;
+@import '../elements/buttons.scss';
 
 // #region Hide data sets
 .chart__outer > input[type='checkbox']:not(:checked) ~ .chart__wrapper table tbody tr td:not(:first-child) {

--- a/assets/sass/components/barchart.component.scss
+++ b/assets/sass/components/barchart.component.scss
@@ -68,6 +68,7 @@
     align-items: flex-start;
     margin-bottom: 0.5rem;
     padding: 0;
+    min-height: 1.5rem;
 
     td {
       // part=value

--- a/assets/sass/components/charts.module.scss
+++ b/assets/sass/components/charts.module.scss
@@ -199,13 +199,13 @@ $chart-height-lg: #{rem(200)} !default;
   }
 
   .key {
-    margin: 0;
+    margin: 0 !important;
 
     &:before {
       content: '';
       height: 0.8em;
       width: 0.8em;
-      margin-right: 0.3em;
+      margin-right: 0.3em !important;
       background-color: var(--chart-colour);
       display: inline-block;
       border-radius: var(--key-border-radius, 4px);
@@ -500,14 +500,37 @@ $chart-height-lg: #{rem(200)} !default;
           &::before {
             content: attr(data-group) '\A';
           }
+
           &[data-label]::before {
             content: attr(data-group) '\A' attr(data-label) '\A';
+          }
+
+          &:has(:is(a, button)) {
+            top: 0;
+            left: 50%;
+            transform: translate(-50%, -100%);
+            font-size: 0.9rem;
+          }
+
+          :is(a, button) {
+            display: inline-block;
+            clear: both;
+            float: left;
+            margin-top: 1rem;
+            margin-right: 1rem;
+            margin-bottom: 0.25em;
+            font-size: 1em;
+          }
+
+          :is(a, button) + :is(a, button) {
+            margin-top: 0;
           }
         }
 
         &:hover span {
           opacity: 1;
           z-index: var(--index-above);
+          pointer-events: all;
         }
       }
 

--- a/assets/sass/components/charts.module.scss
+++ b/assets/sass/components/charts.module.scss
@@ -512,6 +512,10 @@ $chart-height-lg: #{rem(200)} !default;
             font-size: 0.9rem;
           }
 
+          hr {
+            margin: 0;
+            opacity: 0;
+          }
           :is(a, button) {
             display: inline-block;
             clear: both;

--- a/assets/ts/modules/chart.module.ts
+++ b/assets/ts/modules/chart.module.ts
@@ -247,7 +247,11 @@ export const setCellData = function (chartElement: any, table: any) {
 
       if (display != 'none') rowValue += value;
 
-      Array.from(td.querySelectorAll('a, button')).forEach((element: any) => {
+      Array.from(td.querySelectorAll('a, button')).forEach((element: any, index: number) => {
+        if (index == 0) {
+          element.insertAdjacentHTML('beforeBegin', '<hr/>');
+        }
+
         element.classList.add('btn');
         element.classList.add('btn-tertiary');
       });

--- a/assets/ts/modules/chart.module.ts
+++ b/assets/ts/modules/chart.module.ts
@@ -232,14 +232,25 @@ export const setCellData = function (chartElement: any, table: any) {
     let rowValue = 0;
     // Set the data numeric value if not set
     Array.from(tr.querySelectorAll('td:not(:first-child)')).forEach((td: any) => {
-      const value = parseFloat(td.textContent.replace('£', '').replace('%', '').replace(',', ''));
+      // Ignore the buttons and links inside
+      const copyTD = td.cloneNode(true);
+      Array.from(copyTD.querySelectorAll('*')).forEach((element: any) => {
+        element.remove();
+      });
+
+      const value = parseFloat(copyTD.textContent.replace('£', '').replace('%', '').replace(',', ''));
 
       td.setAttribute('data-numeric', value);
-      td.setAttribute('data-value', td.textContent);
+      td.setAttribute('data-value', copyTD.textContent);
 
       const display = getComputedStyle(td).display;
 
       if (display != 'none') rowValue += value;
+
+      Array.from(td.querySelectorAll('a, button')).forEach((element: any) => {
+        element.classList.add('btn');
+        element.classList.add('btn-tertiary');
+      });
     });
 
     tr.setAttribute('data-numeric', rowValue);
@@ -323,9 +334,13 @@ export const setLongestValue = function (chartOuter: any) {
   const table = chartOuter.querySelector('.chart table');
 
   let longestValue = '';
-  Array.from(table.querySelectorAll('tbody tr td:not(:first-child) span')).forEach((td: any) => {
-    if (typeof td.textContent != 'undefined' && td.textContent.length > longestValue.length)
-      longestValue = td.textContent;
+  Array.from(table.querySelectorAll('tbody tr td:not(:first-child)')).forEach((td: any) => {
+    if (
+      typeof td.getAttribute('data-value') != 'undefined' &&
+      td.getAttribute('data-value').length > longestValue.length
+    ) {
+      longestValue = td.getAttribute('data-value');
+    }
   });
   chartWrapper.setAttribute('data-longest-value', longestValue);
 };

--- a/docs/views/charts/BarChart.vue
+++ b/docs/views/charts/BarChart.vue
@@ -342,7 +342,48 @@
       </div>
     </div>
 
-    <h3>Colour</h3>
+    <h3>Stacked bar with menu</h3>
+    <p>Give the user actions against each table cell i.e. view a property or see further evidence.</p>
+    <div class="container bg-light mb-5 visualtest">
+      <div class="row align-items-center">
+        <div class="col-sm-6 mx-auto">
+          <BarChart class="chart--horizontal chart--stacked chart--display-data">
+            <table>
+              <thead>
+                <tr>
+                  <th>Items</th>
+                  <th>Subcat 1</th>
+                  <th>Subcat 2</th>
+                  <th>Subcat 3</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Item 1</td>
+                  <td>100<a href="/">View properties</a><button>Archive</button></td>
+                  <td>150<a href="/">View properties</a><button>Archive</button></td>
+                  <td>150<a href="/">View properties</a><button>Archive</button></td>
+                </tr>
+                <tr>
+                  <td>Item 2</td>
+                  <td>50<a href="/">View properties</a><button>Archive</button></td>
+                  <td>50<a href="/">View properties</a><button>Archive</button></td>
+                  <td>200<a href="/">View properties</a><button>Archive</button></td>
+                </tr>
+                <tr>
+                  <td>Item 3</td>
+                  <td>100<a href="/">View properties</a><button>Archive</button></td>
+                  <td>50<a href="/">View properties</a><button>Archive</button></td>
+                  <td>200<a href="/">View properties</a><button>Archive</button></td>
+                </tr>
+              </tbody>
+            </table>
+          </BarChart>
+        </div>
+      </div>
+    </div>
+
+    <h2>Colour</h2>
 
     <p>
       The only time colours are bound to a particular item is when including singular items which align to the values of
@@ -351,34 +392,35 @@
       Aside from this, please use the applied colours listed below.
     </p>
 
-    <table class="border-0 mb-1">
-      <thead>
-        <tr>
-          <th>Hex code</th>
-          <th>Ref*</th>
-          <th>Colour</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr class="mb-1">
-          <td>#D2F0C9 - Complete/positive</td>
-          <td>success</td>
-          <td class="bg-success" style="min-width: 5rem"></td>
-        </tr>
-        <tr class="mb-1">
-          <td>#FFD280 - In progress/warning</td>
-          <td>warning</td>
-          <td class="bg-warning" style="min-width: 5rem"></td>
-        </tr>
-        <tr>
-          <td>#F5C2C7 - Incomplete/negative</td>
-          <td>danger</td>
-          <td class="bg-danger" style="min-width: 5rem"></td>
-        </tr>
-      </tbody>
-    </table>
-    <p>* Use this reference for when adding to the data-colour-{i} attributes.</p>
-
+    <div>
+      <table class="border-0 mb-1">
+        <thead>
+          <tr>
+            <th>Hex code</th>
+            <th>Ref*</th>
+            <th>Colour</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="mb-1">
+            <td>#D2F0C9 - Complete/positive</td>
+            <td>success</td>
+            <td class="bg-success" style="min-width: 5rem"></td>
+          </tr>
+          <tr class="mb-1">
+            <td>#FFD280 - In progress/warning</td>
+            <td>warning</td>
+            <td class="bg-warning" style="min-width: 5rem"></td>
+          </tr>
+          <tr>
+            <td>#F5C2C7 - Incomplete/negative</td>
+            <td>danger</td>
+            <td class="bg-danger" style="min-width: 5rem"></td>
+          </tr>
+        </tbody>
+      </table>
+      <p>* Use this reference for when adding to the data-colour-{i} attributes.</p>
+    </div>
     <div class="row row-cols-2 row-cols-sm-4 d-none d-sm-flex">
       <div class="col pb-2">
         <span class="label">Chart colour</span>


### PR DESCRIPTION
## Summary of Changes
1. Add menus to the bar charts
2. Include the button and link css to the charts

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /charts/barchart - section Stacked bar with menu

## Ticket(s)
FEG-578 

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] New components work as a Vue component, Web component and as static HTML
- [ ] New components added as an export to src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the rollup config

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
