### PR TITLE
FEG-286 - collapsible-side-menu

### DIFF
--- a/assets/sass/_functions/variables.scss
+++ b/assets/sass/_functions/variables.scss
@@ -776,11 +776,13 @@ $btn-border-radius: $border-radius !default;
 $btn-border-radius-sm: $border-radius-sm !default;
 $btn-border-radius-lg: $border-radius-lg !default;
 
+$btn-transition-duration: 0.15s !default;
+
 $btn-transition:
-  color 0.15s ease-in-out,
-  background-color 0.15s ease-in-out,
-  border-color 0.15s ease-in-out,
-  box-shadow 0.15s ease-in-out !default;
+  color $btn-transition-duration ease-in-out,
+  background-color $btn-transition-duration ease-in-out,
+  border-color $btn-transition-duration ease-in-out,
+  box-shadow $btn-transition-duration ease-in-out !default;
 
 $btn-hover-bg-shade-amount: 15% !default;
 $btn-hover-bg-tint-amount: 15% !default;

--- a/assets/sass/_functions/variables.scss
+++ b/assets/sass/_functions/variables.scss
@@ -1835,6 +1835,8 @@ $theme-colors: map-merge(
     'light': $light,
     'canvas': $canvas,
     'white': #fcfcfc,
+    'activeLink': #e8f9fd,
+    'activeLinkBorder': #1dbde6,
   ),
   $theme-colors
 );
@@ -1931,6 +1933,8 @@ $dark-mode-functional-colors: (
   'btn-secondary-bg-hover': var(--colour-white),
   'btn-secondary-hover': var(--colour-primary-theme),
   'btn-action-hover-bg': var(--colour-canvas-2),
+  'activeLink': #173c45,
+  'activeLinkBorder': #1dbde6,
 );
 
 $wider-colours: (

--- a/assets/sass/components/collapsible-side.scss
+++ b/assets/sass/components/collapsible-side.scss
@@ -39,27 +39,29 @@
 // #region Side menu
 .side-menu {
   position: absolute;
+  z-index: 20;
   top: 0;
   left: 0;
   height: 100%;
   min-height: calc(100vh - var(--nav-height));
-  width: rem(30);
+  width: rem(70);
   height: calc(100% - var(--nav-height));
-  background-color: var(--colour-canvas);
+  padding: 0 rem(40) 0 0;
   transition: width 1s;
-
+  
   &:before {
     content: '';
     position: absolute;
+    z-index: 1;
     top: 0;
-    right: 0;
+    right: rem(40);
     height: 100%;
     border-right: 2px solid var(--colour-border);
   }
 
   @include media-breakpoint-up(sm) {
     left: 0;
-    width: rem(40);
+    width: rem(80);
   }
 
   @include media-breakpoint-up(md) {
@@ -69,7 +71,7 @@
     top: var(--nav-height);
 
     &:not(.open).hover {
-      width: rem(304);
+      width: rem(344);
 
       .btn[class*='fa-']:before {
         content: '\f023' !important;
@@ -81,13 +83,14 @@
     display: var(--btn-display, block);
     position: absolute;
     top: rem(32);
-    right: 0;
+    right: rem(40);
     margin-bottom: 0;
     margin-right: rem(-20);
     background-color: var(--colour-canvas-2);
     border: 2px solid var(--colour-border);
     z-index: 99;
     color: var(--colour-primary-theme);
+    transition: opacity $btn-transition-duration;
 
     &[aria-expanded] {
       // Change icon
@@ -103,7 +106,7 @@
 
   &:is(:hover, :focus-within, :active) .btn {
     border: 2px solid var(--colour-border);
-    color: var(--colour-primary-theme);
+    color: var(--colour-primary);
 
     @include media-breakpoint-up(md) {
       opacity: 1;
@@ -111,13 +114,13 @@
   }
 
   &:is(.open) {
-    width: calc(100% - var(--container-padding-x));
+    width: calc(100% - var(--container-padding-x) + rem(40));
 
     @include media-breakpoint-up(sm) {
-      width: rem(382);
+      width: rem(422);
     }
     @include media-breakpoint-up(md) {
-      width: rem(304);
+      width: rem(344);
     }
   }
 
@@ -125,14 +128,16 @@
   .side-menu-content {
     position: absolute;
     top: 0;
-    right: 0;
-    padding: rem(32) rem(40) 0 0;
+    right: rem(40);
+    padding: rem(32) rem(40) rem(40) 0;
     width: rem(351);
+    background-color: var(--colour-canvas);
     opacity: 0;
     transition: opacity 1s;
     min-height: 100%;
     overflow: auto;
     max-height: 100%;
+    scrollbar-width: thin;
 
     .h3 {
       padding-left: rem(24);
@@ -175,6 +180,8 @@
 
 // #region main content
 .main-content {
+  position: relative;
+  z-index: 10;
   padding-top: rem(24);
   padding-left: rem(60);
 

--- a/assets/sass/components/collapsible-side.scss
+++ b/assets/sass/components/collapsible-side.scss
@@ -1,4 +1,5 @@
 @use '../_func' as *;
+
 // Host
 :host {
   --colour-border: #e9e9e9;
@@ -121,7 +122,6 @@
   }
 
   // Content
-
   .side-menu-content {
     position: absolute;
     top: 0;
@@ -145,6 +145,7 @@
 
       width: rem(382);
     }
+
     @include media-breakpoint-up(md) {
       width: rem(304);
 
@@ -169,87 +170,7 @@
   }
 }
 
-// Links
-::slotted(*[slot='menu']) {
-  padding-left: rem(24);
-
-  @include media-breakpoint-up(sm) {
-    padding-left: rem(40);
-  }
-
-  @include media-breakpoint-up(md) {
-    padding-left: var(--container-padding-x-md);
-  }
-}
-
-::slotted(hr) {
-  border-bottom: 2px solid var(--colour-border) !important;
-  margin-right: rem(-40) !important;
-}
-
-::slotted(a[slot='menu']) {
-  display: block;
-
-  display: block !important;
-  line-height: rem(20) !important;
-  padding: rem(16) rem(40) rem(16) rem(24) !important;
-  margin: 0 !important;
-  flex-shrink: 0;
-  font-size: 1rem !important;
-  font-weight: normal !important;
-  text-decoration: none;
-
-  border-bottom: 2px solid var(--colour-border) !important;
-
-  margin-right: rem(-40) !important;
-
-  @include media-breakpoint-up(sm) {
-    padding-left: rem(40) !important;
-  }
-
-  @include media-breakpoint-up(md) {
-    padding-left: var(--container-padding-x-md) !important;
-  }
-  &:after {
-    display: none;
-  }
-
-  border-right: 2px solid var(--colour-border) !important;
-}
-
-::slotted(a[slot='menu']:where(:hover, :focus, [aria-expanded])) {
-  background-color: var(--side-link-hover) !important;
-}
-
-::slotted(a[slot='menu']:active) {
-  background-color: var(--side-link-hover) !important;
-  font-weight: bold !important;
-}
-
-::slotted(a[slot='menu'][aria-expanded]) {
-  background-color: var(--side-link-hover) !important;
-  font-weight: bold !important;
-  margin-right: #{rem(-40)} !important;
-  position: relative;
-
-  border-right: 2px solid var(--colour-info) !important;
-
-  &:before {
-    content: '';
-    position: absolute;
-    top: 0;
-    right: 0;
-    height: calc(100% + 4px);
-    margin-top: -2px;
-    width: 2px;
-    border-right: 2px solid var(--colour-info);
-    margin-right: -2px;
-
-    @media (forced-colors: active) {
-      border-right: 10px solid var(--colour-info);
-    }
-  }
-}
+// links moved to links.scss
 // #endregion
 
 // #region main content

--- a/assets/sass/elements/links.scss
+++ b/assets/sass/elements/links.scss
@@ -146,23 +146,26 @@ a:where(:not(.btn):not(.brand):not(:has(.card)):not(:has(iam-card))),
 // #endregion
 
 // #region Sidebar link styling including parent group styling
-iam-collapsible-side > * {
-  padding-left: rem(24);
-
-  @include media-breakpoint-up(sm) {
-    padding-left: rem(40);
+iam-collapsible-side {
+  > * {
+    padding-left: rem(24);
+  
+    @include media-breakpoint-up(sm) {
+      padding-left: rem(40);
+    }
+  
+    @include media-breakpoint-up(md) {
+      padding-left: var(--container-padding-x-md);
+    }
   }
 
-  @include media-breakpoint-up(md) {
-    padding-left: var(--container-padding-x-md);
+  hr {
+    border-bottom: 2px solid var(--colour-border) !important;
+    margin-right: rem(-40) !important;
   }
 }
 
-iam-collapsible-side hr {
-  border-bottom: 2px solid var(--colour-border) !important;
-  margin-right: rem(-40) !important;
-}
-
+.vertical-tabs [class*="link"],
 iam-collapsible-side [class*="link"] {
   display: block !important;
   line-height: rem(20) !important;
@@ -175,6 +178,7 @@ iam-collapsible-side [class*="link"] {
   border-bottom: 2px solid var(--colour-border) !important;
   border-right: 2px solid var(--colour-border) !important;
   margin-right: rem(-40) !important;
+  z-index: 2;;
 
   &::after {
     display: none !important;
@@ -193,6 +197,7 @@ iam-collapsible-side [class*="link"] {
   }
 }
 
+.vertical-tabs a,
 iam-collapsible-side a {
   &:hover, &:focus, &[aria-expanded] {
     &:not([class*="active"]) {
@@ -201,6 +206,7 @@ iam-collapsible-side a {
   }
 }
 
+.vertical-tabs [class*="active"],
 iam-collapsible-side [class*="active"] {
   background-color: var(--colour-activeLink) !important;
   border-right-color: var(--colour-activeLinkBorder) !important;
@@ -208,6 +214,7 @@ iam-collapsible-side [class*="active"] {
 }
 
 // Parent links
+.vertical-tabs,
 iam-collapsible-side {
   .parent {
     margin: 0 !important;
@@ -216,7 +223,7 @@ iam-collapsible-side {
 
     li:first-of-type {
       cursor: pointer;
-      
+
       a {
         padding-right: rem(40) !important;
 
@@ -249,6 +256,17 @@ iam-collapsible-side {
 
       li:not(:first-of-type) {
         display: block;
+      }
+    }
+  }
+
+  
+  @include media-breakpoint-up(sm) {
+    .parent {
+      li:not(:first-of-type) {
+        a {
+          padding-left: rem(90) !important;
+        }
       }
     }
   }

--- a/assets/sass/elements/links.scss
+++ b/assets/sass/elements/links.scss
@@ -195,13 +195,15 @@ iam-collapsible-side [class*="link"] {
 
 iam-collapsible-side a {
   &:hover, &:focus, &[aria-expanded] {
-    background-color: #ededed !important;
+    &:not([class*="active"]) {
+      background-color: var(--colour-light) !important;
+    }
   }
 }
 
 iam-collapsible-side [class*="active"] {
-  background-color: #e8f9fd !important;
-  border-right-color: #1dbde6 !important;
+  background-color: var(--colour-activeLink) !important;
+  border-right-color: var(--colour-activeLinkBorder) !important;
   border-right-width: 3px !important;
 }
 
@@ -213,6 +215,8 @@ iam-collapsible-side {
     list-style: none;
 
     li:first-of-type {
+      cursor: pointer;
+      
       a {
         padding-right: rem(40) !important;
 

--- a/assets/sass/elements/links.scss
+++ b/assets/sass/elements/links.scss
@@ -144,3 +144,109 @@ a:where(:not(.btn):not(.brand):not(:has(.card)):not(:has(iam-card))),
 }
 
 // #endregion
+
+// #region Sidebar link styling including parent group styling
+iam-collapsible-side > * {
+  padding-left: rem(24);
+
+  @include media-breakpoint-up(sm) {
+    padding-left: rem(40);
+  }
+
+  @include media-breakpoint-up(md) {
+    padding-left: var(--container-padding-x-md);
+  }
+}
+
+iam-collapsible-side hr {
+  border-bottom: 2px solid var(--colour-border) !important;
+  margin-right: rem(-40) !important;
+}
+
+iam-collapsible-side [class*="link"] {
+  display: block !important;
+  line-height: rem(20) !important;
+  padding: rem(16) rem(24) rem(16) rem(24) !important;
+  margin: 0 !important;
+  flex-shrink: 0;
+  font-size: 1rem !important;
+  font-weight: normal !important;
+  text-decoration: none !important;
+  border-bottom: 2px solid var(--colour-border) !important;
+  border-right: 2px solid var(--colour-border) !important;
+  margin-right: rem(-40) !important;
+
+  &::after {
+    display: none !important;
+  }
+
+  i { // icon
+    margin-right: rem(8) !important;
+  }
+
+  @include media-breakpoint-up(sm) {
+    padding-left: rem(24) !important;
+  }
+
+  @include media-breakpoint-up(md) {
+    padding-left: var(--container-padding-x-md) !important;
+  }
+}
+
+iam-collapsible-side a {
+  &:hover, &:focus, &[aria-expanded] {
+    background-color: #ededed !important;
+  }
+}
+
+iam-collapsible-side [class*="active"] {
+  background-color: #e8f9fd !important;
+  border-right-color: #1dbde6 !important;
+  border-right-width: 3px !important;
+}
+
+// Parent links
+iam-collapsible-side {
+  .parent {
+    margin: 0 !important;
+    padding: 0 !important;
+    list-style: none;
+
+    li:first-of-type {
+      a {
+        padding-right: rem(40) !important;
+
+        &::before {
+          position: absolute;
+          display: block;
+          content: '\f055';
+          font-family: 'Font Awesome 6 Pro';
+          right: 20px;
+          font-weight: 300;
+        }
+      }
+    }
+
+    li:not(:first-of-type) {
+      display: none;
+
+      a {
+        padding-left: rem(90) !important;
+      }
+    }
+
+    &.reveal {
+      li:first-of-type {
+        a::before {
+          content: '\f056';
+          font-weight: bold;
+        }
+      }
+
+      li:not(:first-of-type) {
+        display: block;
+      }
+    }
+  }
+}
+// #endregion

--- a/assets/ts/components/collapsible-side/collapsible-side.component.ts
+++ b/assets/ts/components/collapsible-side/collapsible-side.component.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // Data layer Web component created
 window.dataLayer = window.dataLayer || [];
 window.dataLayer.push({
@@ -31,6 +30,7 @@ class iamCollapsibleSideMenu extends HTMLElement {
 
         <div class="side-menu" part="side-menu">
           <button class="btn btn-compact fa-chevron-right btn-secondary btn-sm btn-collapse" part="btn">Open or close Collapsible menu</button>
+          
           <div class="side-menu-content closed" part="side-menu-content">
             <slot name="menu"></slot>
           </div>
@@ -42,35 +42,46 @@ class iamCollapsibleSideMenu extends HTMLElement {
 
       </div>
     `;
-    this.shadowRoot.appendChild(template.content.cloneNode(true));
+    
+    if (this.shadowRoot) {
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
   }
 
-  connectedCallback() {
+  connectedCallback(): void {
+    if (!this.shadowRoot) return;
+
     const sideMenu = this.shadowRoot.querySelector('.side-menu');
     const sideMenuContent = this.shadowRoot.querySelector('.side-menu-content');
     const mainContent = this.shadowRoot.querySelector('.main-content');
     const button = this.shadowRoot.querySelector('.side-menu > .btn');
 
-    // Load external CSS if needed
-    if (this.hasAttribute('data-css'))
-      this.shadowRoot
-        .querySelector('.styles')
-        .insertAdjacentHTML('beforeend', `@import "${this.getAttribute('data-css')}";`);
+    if (!sideMenu || !sideMenuContent || !mainContent || !button) return;
 
-    // Set sde nav title
-    if (!this.hasAttribute('data-title')) this.setAttribute('data-title', 'configuration');
+    // Load external CSS if needed
+    if (this.hasAttribute('data-css')) {
+      const styles = this.shadowRoot.querySelector('.styles') as HTMLStyleElement;
+      if (styles) {
+          styles.insertAdjacentHTML('beforeend', `@import "${this.getAttribute('data-css')}";`);
+      }
+    }
+
+    // Set side nav title
+    if (!this.hasAttribute('data-title')) {
+        this.setAttribute('data-title', 'configuration');
+    }
 
     sideMenuContent.insertAdjacentHTML('afterbegin', `<span class="h3">${this.getAttribute('data-title')}</span>`);
     mainContent.insertAdjacentHTML('afterbegin', `<span class="h3">${this.getAttribute('data-title')}</span>`);
 
-    if (this.querySelector(':scope > :is(h1,h2,h3,h4,h5,h6)')) {
-      this.querySelector(':scope > :is(h1,h2,h3,h4,h5,h6)').classList.add('h4');
-      this.querySelector(':scope > :is(h1,h2,h3,h4,h5,h6)').classList.add('main-content__title');
+    const titleElement = this.querySelector(':scope > :is(h1,h2,h3,h4,h5,h6)') as HTMLElement;
+    if (titleElement) {
+        titleElement.classList.add('h4', 'main-content__title');
     }
 
     if (this.hasAttribute('open') && window.innerWidth > 992) {
-      sideMenu.classList.add('open');
-      button.setAttribute('aria-expanded', true);
+        sideMenu.classList.add('open');
+        button.setAttribute('aria-expanded', 'true');
     }
 
     // Open the menu
@@ -80,7 +91,7 @@ class iamCollapsibleSideMenu extends HTMLElement {
 
         setTimeout(function () {
           sideMenu.classList.add('open');
-          button.setAttribute('aria-expanded', true);
+          button.setAttribute('aria-expanded', 'true');
         }, 100);
       } else {
         sideMenu.classList.remove('open');
@@ -123,6 +134,26 @@ class iamCollapsibleSideMenu extends HTMLElement {
           }, 1000); // Delay until its close so the animation is broken
       }
     });
+
+    const sideMenuParentGroups = this.querySelectorAll('.parent')
+    const sideMenuParentGroupsTopLinks = this.querySelectorAll('.parent > li:first-of-type')
+
+    sideMenuParentGroupsTopLinks?.forEach(parentLink => {
+      parentLink.addEventListener('click', () => {
+        if (!parentLink || !parentLink.parentElement) return false // make sure elements exist
+
+        if (parentLink.parentElement.classList.contains('reveal')) {
+          parentLink.parentElement.classList.remove('reveal') // remove if clicking a revealed parent
+        }
+        else { // remove other reveals and add reveal to this one
+          sideMenuParentGroups?.forEach(parentGroup => {
+            parentGroup.classList.remove('reveal')
+          })
+
+          parentLink.parentElement.classList.add('reveal')
+        }
+      })
+    })
   }
 }
 

--- a/audit.json
+++ b/audit.json
@@ -1,7 +1,7 @@
 {
-  "css_size": "174kb",
-  "css_core_size": "167kb",
-  "js_size": "77kb",
+  "css_size": "207kb",
+  "css_core_size": "185kb",
+  "js_size": "16kb",
   "logo_size": "25kb",
   "img_size": "151kb",
   "img_count": 3,

--- a/docs/views/standalone/CollapsibleSideMenu.vue
+++ b/docs/views/standalone/CollapsibleSideMenu.vue
@@ -6,7 +6,7 @@
       <CollapsibleSideMenu data-title="Configuration" open open-always>
         <div slot="menu">
           <label for="test1">Active branch</label>
-          <select class="form-select" name="test1" id="test1">
+          <select id="test1" class="form-select" name="test1">
             <option value="1" selected>Newcastle</option>
             <option value="2">Two</option>
             <option value="2">Three</option>
@@ -15,9 +15,24 @@
         </div>
 
         <hr slot="menu" />
-        <a href="/" slot="menu">Agency settings</a>
-        <a href="/" slot="menu">Control panel</a>
-        <a href="/" slot="menu" class="selected">Contact us</a>
+
+        <a slot="menu" href="/" class="link"><i class="fa-light fa-alien"></i>Control panel</a>
+        <a slot="menu" href="/" class="link selected">Contact us</a>
+        <a slot="menu" href="/" class="link active">Active Class</a>
+        <a slot="menu" href="/" class="router-link-active router-link-exact-active">Vue's Active Class</a>
+        <a slot="menu" href="/" class="link">Example link</a>
+        <a slot="menu" href="/" class="link">Example link with a really long name in here for some reason</a>
+      
+        <ul slot="menu" class="parent">
+          <li><a class="link">Parent link</a></li>
+          <li><a href="/" class="link"><i class="fa-light fa-house"></i>Example link</a></li>
+          <li><a href="/" class="link">Example link with a really long name in here for some reason</a></li>
+          <li><a href="/" class="link">Sub link 1</a></li>
+          <li><a href="/" class="link">Sub link 2</a></li>
+          <li><a href="/" class="link active">Sub link (active)</a></li>
+          <li><a href="/" class="router-link-active router-link-exact-active">Sub link (vue active)</a></li>
+        </ul>
+        <a slot="menu" href="/" class="link">Further sub links after group</a>
 
         <h1>Inspections</h1>
         <p>

--- a/docs/views/standalone/CollapsibleSideMenu.vue
+++ b/docs/views/standalone/CollapsibleSideMenu.vue
@@ -1,9 +1,14 @@
+<script lang="ts" setup>
+  import CollapsibleSideMenu from '@/components/CollapsibleSideMenu/CollapsibleSideMenu.vue';
+  import CrmNav from '../CrmNav.vue';
+</script>
+
 <template>
   <div>
     <CrmNav></CrmNav>
 
     <main>
-      <CollapsibleSideMenu data-title="Configuration" open open-always>
+      <CollapsibleSideMenu data-title="Configuration" open>
         <div slot="menu">
           <label for="test1">Active branch</label>
           <select id="test1" class="form-select" name="test1">
@@ -47,17 +52,3 @@
     </main>
   </div>
 </template>
-
-<script>
-  import Nav from '@/components/Nav/Nav.vue';
-  import CollapsibleSideMenu from '@/components/CollapsibleSideMenu/CollapsibleSideMenu.vue';
-  import CrmNav from '../CrmNav.vue';
-
-  export default {
-    components: {
-      Nav,
-      CollapsibleSideMenu,
-      CrmNav,
-    },
-  };
-</script>

--- a/src/components/CollapsibleSideMenu/CollapsibleSideMenu.vue
+++ b/src/components/CollapsibleSideMenu/CollapsibleSideMenu.vue
@@ -1,18 +1,12 @@
+<script setup lang="ts">
+import iamCollapsibleSideMenu from '../../../assets/js/components/collapsible-side/collapsible-side.component.js';
+
+if (!window.customElements.get('iam-collapsible-side'))
+  window.customElements.define('iam-collapsible-side', iamCollapsibleSideMenu);
+</script>
+
 <template>
   <iam-collapsible-side>
     <slot></slot>
   </iam-collapsible-side>
 </template>
-
-<script>
-  import iamCollapsibleSideMenu from '../../../assets/js/components/collapsible-side/collapsible-side.component.js';
-
-  if (!window.customElements.get('iam-collapsible-side'))
-    window.customElements.define('iam-collapsible-side', iamCollapsibleSideMenu);
-
-  export default {
-    name: 'CollapsibleSideMenu',
-    props: {},
-    mounted() {},
-  };
-</script>


### PR DESCRIPTION
## Summary of Changes
1. Added sub group support
2. Updated styling to design
3. Improved some minor variable related styling
4. Converted standalone page to composition api and typescript
5. Added more typescript safety nets to ts file
6. Added generic 'active' class catchers for vue's router classes and generic router class
7. Added and improved to existing dark mode support

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /standalone/collapsible-side-menu

## Ticket(s)
FEG-286
FEG-416

## Pull Request npm task ran

[x] Has the pull request npm task been ran?

This will run the unit tests, lint the repo, run prettier and audit the file sizes.

## Checklist

The below needs to be done before a pull request can be approved:

- [x] New components work as a Web component and a Vue component
- [x] New vue components added as an export in src/index.js
- [x] New components/features have sufficient unit tests
- [x] New components/features have sufficient documentation
- [x] New component has dataLayer events added
- [x] New component is added to the components.json file so it is picked up in the rollup config file
- [x] New component is added to the components const in the main scripts file

## Accesibility check list

- [x] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [x] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [x] New components/features have hover, focus and active states on all the links/buttons
- [x] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
