### PR TITLE
move the bootstrap grid classses back into out css

### DIFF
--- a/assets/sass/_corefiles.scss
+++ b/assets/sass/_corefiles.scss
@@ -8,6 +8,7 @@
 @use 'foundations/colours';
 
 @use 'foundations/reboot';
+@use 'foundations/debug';
 
 /*  Elements */
 @use '_elements';

--- a/assets/sass/_utilities.scss
+++ b/assets/sass/_utilities.scss
@@ -33,3 +33,4 @@
 @use './utilities/visible';
 @use './utilities/columns';
 @use './utilities/shadow';
+@use './utilities/grid';

--- a/assets/sass/error.scss
+++ b/assets/sass/error.scss
@@ -7,7 +7,6 @@
 
 
 @use '_corefiles';
-@use '_grid';
 @use '_bs_grid';
 @use '_bs_utilities';
 @use '_utilities';

--- a/assets/sass/foundations/debug.scss
+++ b/assets/sass/foundations/debug.scss
@@ -1,0 +1,6 @@
+@layer debug {
+
+  .debug .row {
+    outline: 2px solid red;
+  }
+}

--- a/assets/sass/foundations/root.scss
+++ b/assets/sass/foundations/root.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use '../func' as *;
 
-@layer legacy, reset, elements, components, templates, overrides, utilities;
+@layer legacy, reset, elements, components, templates, overrides, utilities, debug;
 
 @layer reset {
   :root {

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -2,6 +2,5 @@
 
 @use '_fonts';
 @use '_corefiles';
-@use '_grid';
 @use '_utilities';
 @use '_print';

--- a/assets/sass/utilities/grid.scss
+++ b/assets/sass/utilities/grid.scss
@@ -1,6 +1,11 @@
 @use 'sass:math';
 @use 'sass:map';
-@use '_func' as *;
+
+@use 'sass:meta';
+@use 'sass:list';
+@use 'sass:string';
+
+
 
 $columns: 12;
 $rows-per-page: 20;
@@ -123,7 +128,7 @@ $breakpoints: (
 }
 /* #endregion */
 
-@layer reset {
+@layer utilities {
   /* #region Main grid setup */
   body {
     --excess-space: calc((100% - var(--max-width)) / 2);
@@ -242,7 +247,7 @@ $breakpoints: (
   }
 
   *:not(:where(html, body)):has(
-      :is([class*='cols-'], [class*='col-start-'], [class*='col-end-'], [class*='col-span-'])
+      :is([class*='cols-'], [class*='col-start-'], [class*='col-end-'], [class*='col-span-']):not([class*='row-cols-'])
     ) {
     display: grid;
     grid-template-columns: subgrid;
@@ -293,7 +298,7 @@ $breakpoints: (
     $count: math.div($columns, $i);
 
     .cols-#{$i} > * {
-      grid-column: auto / span #{math.floor($count)};
+      grid-column: auto / span #{math.floor($count)}!important;
     }
   }
   
@@ -318,8 +323,10 @@ $breakpoints: (
 
   /* #endregion */
 
+  /* #region auto grid */
   .auto-grid {
     display: flex;
+    flex-wrap: nowrap;
     column-gap: var(--gap);
 
     > * {
@@ -350,4 +357,108 @@ $breakpoints: (
       }
     }
   }
+  /* #endregion */
+
+  /* #region Bootstrap grid */
+  .row {
+    
+    display: flex;
+    flex-wrap: wrap;
+    margin-right: calc(-0.5 * var(--gap)); /*  stylelint-disable-line function-disallowed-list */
+    margin-left: calc(-0.5 * var(--gap)); /*  stylelint-disable-line function-disallowed-list */
+
+    > * {
+      
+      flex-shrink: 0;
+      width: 100%;
+      max-width: 100%;
+      padding-right: calc(var(--gap) * 0.5);
+      padding-left: calc(var(--gap) * 0.5);
+    }
+  }
+  
+  @for $i from 1 through 12 {
+    .col-#{$i} {
+      flex: 0 0 auto;
+      $width: math.div($i, 12);
+      width: math.percentage($width);
+    }
+  }
+
+  .row-cols-auto {
+
+    display: flex;
+    flex: 0 0 auto;
+    width: auto;
+
+    > * {
+      display: block!important;
+      width: 100%;
+    }
+  }
+  
+  @for $i from 1 through 4 {
+    .row-cols-#{$i} {
+      
+      display: flex;
+
+      > * {
+        display: block!important;
+        width: math.div(100%, $i);
+      }
+    }
+  }
+
+
+  @media screen and (min-width: 36em) {
+    
+    @for $i from 1 through 4 {
+      .row-cols-sm-#{$i} {
+        > * {
+          flex: 0 0 auto;
+          width: calc(100% / #{$i});
+        }
+      }
+    }
+    
+    .col-sm-auto {
+      flex: 0 0 auto;
+      width: auto;
+    }
+
+    @for $i from 1 through 12 {
+      .col-sm-#{$i} {
+        flex: 0 0 auto;
+        $width: math.div($i, 12);
+        width: math.percentage($width);
+      }
+    }
+  }
+
+  @media screen and (min-width: 62em) {
+    
+    @for $i from 1 through 4 {
+      .row-cols-md-#{$i} {
+        > * {
+          flex: 0 0 auto;
+          width: calc(100% / #{$i});
+        }
+      }
+    }
+    
+    .col-md-auto {
+      flex: 0 0 auto;
+      width: auto;
+    }
+
+    @for $i from 1 through 12 {
+      .col-md-#{$i} {
+        flex: 0 0 auto;
+        $width: math.div($i, 12);
+        width: math.percentage($width);
+      }
+    }
+  }
+
+  /* #endregion */
 }

--- a/docs/assets/styles.scss
+++ b/docs/assets/styles.scss
@@ -15,8 +15,6 @@ $fontPath: '/fonts/';
 
 @use '../../assets/sass/_corefiles';
 
-@use '../../assets/sass/_grid';
-@use '../../assets/sass/_bs_grid';
 
 @use '../../assets/sass/_functions/mixins' as *;
 //@use '../../assets/sass/_bs_utilities' as *;


### PR DESCRIPTION
## Summary of Changes
1. a
2. b
3. c

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /page

## Ticket(s)
FEG-999

## Pull Request npm task ran

[ ] Has the pull request npm task been ran?

This will run the unit tests, lint the repo, run prettier and audit the file sizes.

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] New components work as a Web component and a Vue component
- [ ] New vue components added as an export in src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the components.json file so it is picked up in the rollup config file
- [ ] New component is added to the components const in the main scripts file

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
