### PR TITLE
limit the number of checkboxes

### DIFF
--- a/assets/ts/components/form/form.component.ts
+++ b/assets/ts/components/form/form.component.ts
@@ -147,6 +147,8 @@ class iamForm extends HTMLElement {
 
   limitCheckboxes = (event?:Event):void => {
 
+    
+
     const target = event?.target instanceof HTMLInputElement ? event.target : null;
     const changedCheckbox = target?.matches('input[type="checkbox"]') ? target : null;
     const checkboxLimitGroup = changedCheckbox?.closest('[data-checkbox-limit]');
@@ -158,13 +160,27 @@ class iamForm extends HTMLElement {
         ];
 
     checkboxLimitGroups.forEach((group) => {
-
+      
       const limit = this.getCheckboxLimit(group);
       const checked = Array.from(group.querySelectorAll('input[type="checkbox"]:checked'));
+      const notChecked = Array.from(group.querySelectorAll('input[type="checkbox"]:not(:checked)'));
+
+      notChecked.forEach((checkbox) => {
+
+        checkbox.setAttribute('disabled','disabled');
+      });
+      
+      if(checked.length < limit){
+        notChecked.forEach((checkbox) => {
+
+          checkbox.removeAttribute('disabled');
+        });
+      }
 
       if(checked.length <= limit)
         return;
-
+      
+      
       if(changedCheckbox?.checked && group.contains(changedCheckbox)) {
         changedCheckbox.checked = false;
         return;

--- a/assets/ts/components/form/form.component.ts
+++ b/assets/ts/components/form/form.component.ts
@@ -138,6 +138,45 @@ class iamForm extends HTMLElement {
     });
   }
 
+  getCheckboxLimit = (element):number => {
+
+    const limit = parseInt(element.getAttribute('data-checkbox-limit') || '10', 10);
+
+    return !isNaN(limit) && limit > 0 ? limit : 10;
+  }
+
+  limitCheckboxes = (event?:Event):void => {
+
+    const target = event?.target instanceof HTMLInputElement ? event.target : null;
+    const changedCheckbox = target?.matches('input[type="checkbox"]') ? target : null;
+    const checkboxLimitGroup = changedCheckbox?.closest('[data-checkbox-limit]');
+    const checkboxLimitGroups = checkboxLimitGroup
+      ? [checkboxLimitGroup]
+      : [
+          ...(this.hasAttribute('data-checkbox-limit') ? [this] : []),
+          ...Array.from(this.querySelectorAll('[data-checkbox-limit]')),
+        ];
+
+    checkboxLimitGroups.forEach((group) => {
+
+      const limit = this.getCheckboxLimit(group);
+      const checked = Array.from(group.querySelectorAll('input[type="checkbox"]:checked'));
+
+      if(checked.length <= limit)
+        return;
+
+      if(changedCheckbox?.checked && group.contains(changedCheckbox)) {
+        changedCheckbox.checked = false;
+        return;
+      }
+
+      checked.slice(limit).forEach((checkbox) => {
+
+        checkbox.checked = false;
+      });
+    });
+  }
+
   connectedCallback(): void {
 
     const form = this.querySelector('form');
@@ -181,9 +220,10 @@ class iamForm extends HTMLElement {
     this.readonlyIf();
     this.writeIf();
     this.emptyIf();
+    this.limitCheckboxes();
     
 
-    form.addEventListener('change', () => {
+    form.addEventListener('change', (event) => {
 
       this.showIf();
       this.hideIf();
@@ -193,6 +233,7 @@ class iamForm extends HTMLElement {
       this.readonlyIf();
       this.writeIf();
       this.emptyIf();
+      this.limitCheckboxes(event);
 
       Array.from(form.querySelectorAll('.conditional [data-conditional-required], .conditional [data-conditional-data-required]')).forEach((input) => {
 

--- a/docs/views/form-components/FormDoc.vue
+++ b/docs/views/form-components/FormDoc.vue
@@ -83,7 +83,17 @@
     </form>
     </Form>
 
-
+    <h2 class="pt-5">Limit the number of checkboxes</h2>
+    <Form>
+      <form>
+        <fieldset data-checkbox-limit="2">
+          <label><input type="checkbox" name="test" value="1"/> 1</label>
+          <label><input type="checkbox" name="test" value="2"/> 2</label>
+          <label><input type="checkbox" name="test" value="3"/> 3</label>
+          <label><input type="checkbox" name="test" value="4"/> 4</label>
+        </fieldset>
+      </form>
+    </Form>
 
     <Integration component="fileupload" componentName="iam-fileupload">
       <template #web-component>


### PR DESCRIPTION
## Summary of Changes
1. Add the ability to limit the number of checkboxes being set

**Note** This PR was mostly done with AI

## Review
Open up the preview site (see the below netlify comment below) and navigate to:
- /form-components/form

## Ticket(s)
FEG-913

## Pull Request npm task ran

[ ] Has the pull request npm task been ran?

This will run the unit tests, lint the repo, run prettier and audit the file sizes.

## Checklist

The below needs to be done before a pull request can be approved:

- [ ] New components work as a Web component and a Vue component
- [ ] New vue components added as an export in src/index.js
- [ ] New components/features have sufficient unit tests
- [ ] New components/features have sufficient documentation
- [ ] New component has dataLayer events added
- [ ] New component is added to the components.json file so it is picked up in the rollup config file
- [ ] New component is added to the components const in the main scripts file

## Accesibility check list

- [ ] New components/features are accessible to keyboard users (All links/buttons are tabbable, All content is accessible)
- [ ] New components/features are accessible to non-JS users (All links/buttons are tabbable, All content is accessible), this may have visual differences
- [ ] New components/features have hover, focus and active states on all the links/buttons
- [ ] New components/features work when in dark mode and high contrast mode. Buttons, links and icons should still look like what they are.
