### PR TITLE
Fix ajax search response schema handling

### DIFF
--- a/assets/ts/modules/search.ts
+++ b/assets/ts/modules/search.ts
@@ -1,5 +1,30 @@
+import { resolvePath, isTraversable } from './helpers';
 
-const search = async(component, datalistElement: HTMLDataListElement, searchTerm: string) => {
+type SearchResultItem = Record<string, any>;
+
+const appendDatalistOption = (
+  datalistElement: HTMLDataListElement,
+  item: SearchResultItem,
+  valueSchema: string,
+  displaySchema: string,
+  groupLabel = ''
+): void => {
+  const resolvedValue = resolvePath(item, valueSchema, undefined);
+  const resolvedDisplay = resolvePath(item, displaySchema, undefined);
+  const fallbackValue = isTraversable(item) ? '' : item;
+  const actualValue =
+    resolvedValue ?? item?.value ?? item?.id ?? resolvedDisplay ?? item?.title ?? item?.label ?? fallbackValue;
+  const displayValue = String(resolvedDisplay ?? item?.title ?? item?.label ?? actualValue).replace('\n', ', ');
+
+  if (!displayValue) return;
+
+  const optionElement = document.createElement('option');
+  optionElement.value = String(actualValue);
+  optionElement.textContent = `${groupLabel}${displayValue}`;
+  datalistElement.appendChild(optionElement);
+};
+
+const search = async (component, datalistElement: HTMLDataListElement, searchTerm: string) => {
   let url = component.getAttribute('data-url');
 
   if (!url) return;
@@ -16,33 +41,28 @@ const search = async(component, datalistElement: HTMLDataListElement, searchTerm
   // Create a new controller so it can be aborted if new fetch made
   window.controller[url] = new AbortController();
   const { signal } = window.controller[url];
-  
+
   const requestOptions = {
     signal: signal,
     method: method,
     headers: new Headers({
       'Content-Type': 'application/json',
-      Accept: 'application/json'
-    })
+      Accept: 'application/json',
+    }),
   };
 
   if (method.toUpperCase() === 'GET') {
-
     component.querySelectorAll('input,select').forEach((input) => {
-
-      const name = input.getAttribute('name'); 
+      const name = input.getAttribute('name');
       const value = input.value;
 
       if (name && value) {
         url += `${url.includes('?') ? '&' : '?'}${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
       }
     });
-
-  }
-  else {
+  } else {
     component.querySelectorAll('input,select').forEach((input) => {
-
-      const name = input.getAttribute('name'); 
+      const name = input.getAttribute('name');
       const value = input.value;
 
       if (name && value) {
@@ -55,22 +75,39 @@ const search = async(component, datalistElement: HTMLDataListElement, searchTerm
 
   try {
     await fetch(url, requestOptions)
-    .then((response) => response.json())
-    .then((response) => {
+      .then((response) => response.json())
+      .then((response) => {
+        const loopSchema = component.hasAttribute('data-schema') ? component.getAttribute('data-schema') || '' : 'data';
+        const valueSchema = component.hasAttribute('data-value-schema')
+          ? component.getAttribute('data-value-schema') || ''
+          : 'value';
+        const displaySchema = component.hasAttribute('data-display-schema')
+          ? component.getAttribute('data-display-schema') || ''
+          : 'label';
+        const loopValues = resolvePath(response, loopSchema, []);
 
-      for (const [key, value] of Object.entries(response.data)) {
+        if (isTraversable(loopValues) && typeof loopValues.forEach == 'function') {
+          loopValues.forEach((item) => {
+            appendDatalistOption(datalistElement, item, valueSchema, displaySchema);
+          });
+        } else if (loopValues && typeof loopValues == 'object') {
+          for (const [key, value] of Object.entries(loopValues)) {
+            if (isTraversable(value) && typeof value.forEach == 'function') {
+              value.forEach((item) => {
+                appendDatalistOption(datalistElement, item, valueSchema, displaySchema, `${key}: `);
+              });
+            }
+          }
+        }
 
-        datalistElement.insertAdjacentHTML('beforeend', `<option value="${value.value}">${value.title}</option>`);
-      }
+        filterDatalist(datalistElement, searchTerm);
 
-      filterDatalist(datalistElement, searchTerm);
-
-      return response;
-    });
+        return response;
+      });
   } catch (error) {
     console.log(error);
   }
-}
+};
 
 export const filterDatalist = (datalistElement: HTMLDataListElement, searchTerm: string): void => {
   for (const optionElement of datalistElement.options) {
@@ -83,12 +120,14 @@ export const filterDatalist = (datalistElement: HTMLDataListElement, searchTerm:
   }
 };
 
-export const datalistSelectOption = (component, inputElement: HTMLInputElement, optionElement: HTMLOptionElement): void => {
-  
+export const datalistSelectOption = (
+  component,
+  inputElement: HTMLInputElement,
+  optionElement: HTMLOptionElement
+): void => {
   const datalistElement = optionElement.closest('datalist') as HTMLDataListElement | null;
   const optionText = optionElement.textContent?.trim() || optionElement.value;
   const inputName = inputElement.getAttribute('name') || '';
-
 
   inputElement.value = optionText;
   inputElement.setAttribute('data-value', optionText);
@@ -96,28 +135,24 @@ export const datalistSelectOption = (component, inputElement: HTMLInputElement, 
   inputElement.setAttribute('placeholder', optionText);
 
   // Make sure the value of the option is passed when in a form
-  if(optionElement.value && optionElement.value !== optionText){
-
-    if(!component.querySelector(`input[name="${inputName}Alt"]`))
-      component.insertAdjacentHTML('beforeend', `<input type="hidden" name="${inputName}Alt" value="${optionElement.value}">`);
-    else      
-      component.querySelector(`input[name="${inputName}Alt"]`).value = optionElement.value;
-  }
-  else {
-    if(component.querySelector(`input[name="${inputName}Alt"]`))
+  if (optionElement.value && optionElement.value !== optionText) {
+    if (!component.querySelector(`input[name="${inputName}Alt"]`))
+      component.insertAdjacentHTML(
+        'beforeend',
+        `<input type="hidden" name="${inputName}Alt" value="${optionElement.value}">`
+      );
+    else component.querySelector(`input[name="${inputName}Alt"]`).value = optionElement.value;
+  } else {
+    if (component.querySelector(`input[name="${inputName}Alt"]`))
       component.querySelector(`input[name="${inputName}Alt"]`)!.remove();
   }
-
 
   // Set the active value on the datalist option
   if (!datalistElement) return;
   for (const optionLoopElement of datalistElement.options) {
-    
-    if (optionLoopElement === optionElement)
-      optionLoopElement.classList.add('active');
-    else
-      optionLoopElement.classList.remove('active');
+    if (optionLoopElement === optionElement) optionLoopElement.classList.add('active');
+    else optionLoopElement.classList.remove('active');
   }
-}
+};
 
 export default search;


### PR DESCRIPTION
### Motivation
- Restore Ajax search compatibility with configured response schemas so components that use `data-schema`, `data-value-schema`, and `data-display-schema` continue to work with nested or renamed response fields.
- Prevent the prior hard-coded `response.data` iteration from throwing on payloads that expose results under other paths (breaking integrations like `data-schema="results"`).
- Maintain reasonable fallbacks so older JSON shapes (e.g., `title`/`value` pairs) still populate the datalist.

### Description
- Import and use `resolvePath` and `isTraversable` and add an `appendDatalistOption` helper that resolves `value` and `display` using `data-value-schema` and `data-display-schema` with safe fallbacks.
- Replace the previous hard-coded `Object.entries(response.data)` loop with schema-aware logic that reads `data-schema` for the loop, supports array payloads, and supports grouped/object payloads by iterating nested arrays.
- Improve option construction so the option `value` and displayed text come from resolved fields (or sensible fallbacks like `id`, `value`, `title`, `label`) and ensure grouped labels are prefixed when iterating keyed objects.
- Minor TypeScript typing and formatting updates to the module for clarity and tooling compatibility.

### Testing
- Ran TypeScript checks with `tsc --project tscompileconfig.json --rootDir assets/ts --ignoreDeprecations 6.0 --noEmit` which succeeded.
- Ran formatting checks with `prettier --check assets/ts/modules/search.ts` which passed.
- Performed `tsc` + `prettier` no-emit validation and `git diff --check` to detect syntax/style issues which returned clean results.
- `npm run compile:ts` / full repo linting could not be executed in this environment because local `node_modules` are not installed, so ESLint/npm-based checks were not fully run here (partial lint attempts reported missing local dependencies).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a203c095a308331ae8ca3d920d2766c)